### PR TITLE
Fix: update minimum PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To get started with development:
 
 - Gutenberg plugin (latest)
 - WordPress 6.6+ (Will be 6.7 at the time of release)
-- PHP 7.0+
+- PHP 7.2.24+
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html) or later
 
 Some theme features / PRs may require Gutenberg trunk and will be described or tagged accordingly.

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org
 Description: 
 Requires at least: 6.6
 Tested up to: 6.6
-Requires PHP: 7.0
+Requires PHP: 7.2.24
 Version: 1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
### Fixes #8 

- In `styles.css` and `README.md`, update PHP version to `7.2.24` per new minimum requirements in WordPress core