### PR TITLE
Updated Php Version in readme.txt file

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Requires at least: 6.6
 Tested up to: 6.6
-Requires PHP: 7.0
+Requires PHP: 7.2.24
 Stable tag: 1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Updated PHP version to 7.2.24 in `readme.txt` file as per new minimum requirements in WordPress core (It was already updated in style.css in [#13).](https://github.com/WordPress/twentytwentyfive/pull/13)