### PR TITLE
Update template parts in theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -69,11 +69,13 @@
 	"templateParts": [
 		{
 			"area": "header",
-			"name": "Header"
+			"name": "header",
+			"title": "Header"
 		},
 		{
 			"area": "footer",
-			"name": "Footer"
+			"name": "footer",
+			"title": "Footer"
 		}
 	]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
<!-- Describe the purpose or reason for the pull request -->
When you select the header or footer template part in the Site Editor,
- The template part name is lowercase
- The "Design" panel in the settings sidebar is missing, so there are no patterns to choose from.

This PR corrects the name parameter and adds a title to the template parts in theme.json,
so that users can select header and footer patterns and the names displays as "Header" not "header".

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**

1. Activate Gutenberg ( Note I am testing with Gutenberg **trunk**)
2. Apply the PR
3. Open the Site Editor and edit any template.
4. Open the List view. Confirm that the names of the template parts show as "Header" and "Footer".
5. With the template part selected, confirm that the sidebar shows the Design panel, including the header or footer patterns from WordPress core.
