### PR TITLE
Use wp cli to set development mode true

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To get started with development:
 
 Also, consider enabling [development mode](https://make.wordpress.org/core/2023/07/14/configuring-development-mode-in-6-3/) with `define( 'WP_DEVELOPMENT_MODE', 'theme' );` in your `wp-config.php`. This will help minimize caching of `theme.json` while you're developing.
 
-To enable development mode using [WP CLI](https://developer.wordpress.org/cli/commands/config/set/) use the following command in your terminal inside your installation directory `wp config set 'WP_DEVELOPMENT_MODE' theme --raw`.
+To enable development mode using [WP CLI](https://developer.wordpress.org/cli/commands/config/set/) use the following command in your terminal inside your installation directory `wp config set 'WP_DEVELOPMENT_MODE' theme`.
 
 ### Pattern creation guidelines
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ To get started with development:
 
 Also, consider enabling [development mode](https://make.wordpress.org/core/2023/07/14/configuring-development-mode-in-6-3/) with `define( 'WP_DEVELOPMENT_MODE', 'theme' );` in your `wp-config.php`. This will help minimize caching of `theme.json` while you're developing.
 
+To enable development mode using [WP CLI](https://developer.wordpress.org/cli/commands/config/set/) use the following command in your terminal inside your installation directory `wp config set 'WP_DEVELOPMENT_MODE' true --raw`.
+
 ### Pattern creation guidelines
 
 [Reference guide for patterns in the handbook](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-patterns/).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To get started with development:
 
 Also, consider enabling [development mode](https://make.wordpress.org/core/2023/07/14/configuring-development-mode-in-6-3/) with `define( 'WP_DEVELOPMENT_MODE', 'theme' );` in your `wp-config.php`. This will help minimize caching of `theme.json` while you're developing.
 
-To enable development mode using [WP CLI](https://developer.wordpress.org/cli/commands/config/set/) use the following command in your terminal inside your installation directory `wp config set 'WP_DEVELOPMENT_MODE' true --raw`.
+To enable development mode using [WP CLI](https://developer.wordpress.org/cli/commands/config/set/) use the following command in your terminal inside your installation directory `wp config set 'WP_DEVELOPMENT_MODE' theme --raw`.
 
 ### Pattern creation guidelines
 


### PR DESCRIPTION
Adds instructions to set development mode to true using wp cli in the terminal

<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

<!-- Describe the purpose or reason for the pull request -->

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**

<!-- Provide steps for testing -->
<!-- 1. Activate the theme. -->
<!-- 2. Visit the archives page. -->
<!-- 3. etc. -->
