### PR TITLE
Correct theme var references for font-size

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -36,7 +36,7 @@
 					"slug": "accent-1"
 				},
 				{
-					"color": "#F6CFF4", 
+					"color": "#F6CFF4",
 					"name": "Accent 2",
 					"slug": "accent-2"
 				},
@@ -111,10 +111,10 @@
 				"right": "var(--wp--preset--spacing--50)"
 			}
 		},
-		"blocks":{
+		"blocks": {
 			"core/site-title": {
 				"typography": {
-					"fontSize": "var:preset|fontSize|medium",
+					"fontSize": "var:preset|font-size|medium",
 					"fontWeight": "700",
 					"letterSpacing": "-2"
 				},
@@ -128,13 +128,13 @@
 			},
 			"core/site-tagline": {
 				"typography": {
-					"fontSize": "var:preset|fontSize|small",
+					"fontSize": "var:preset|font-size|small",
 					"letterSpacing": "-1"
 				}
 			},
 			"core/navigation": {
 				"typography": {
-					"fontSize": "var:preset|fontSize|small",
+					"fontSize": "var:preset|font-size|small",
 					"letterSpacing": "-1"
 				}
 			}


### PR DESCRIPTION
**Description**

This PR updates the references to the font size theme variable to correctly use `kebab-case` instead of `camelCase`. This change is required to correctly reference CSS custom properties generated by the theme.

**Screenshots**

Before:
<img width="421" alt="image" src="https://github.com/user-attachments/assets/29c67419-1006-4f8d-99cf-47bba88f19a8">

After:
<img width="373" alt="image" src="https://github.com/user-attachments/assets/3486f79e-4846-4e6f-9c3b-a4f543dac6b8">


**Testing Instructions**

1. Insert one of the styled blocks (either site title, site tagline or navigation)
2. Inspect the CSS to check whether the font size referenced in theme.json is being applied
