### PR TITLE
Navigation: Set a default font size

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -233,6 +233,11 @@
 					"fontSize": "var:preset|font-size|medium",
 					"fontWeight": "700"
 				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontSize": "var:preset|font-size|small"
+				}
 			}
 		},
 		"elements": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
The font size for the navigation block was removed when I tried to solve the merge conflict on https://github.com/WordPress/twentytwentyfive/pull/93, this adds it back
