### PR TITLE
Remove duplicate typography settings

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -152,10 +152,7 @@
 					"size": "2.625rem",
 					"slug": "xx-large"
 				}
-			]
-		},
-		"useRootPaddingAwareAlignments": true,
-		"typography": {
+			],
 			"fontFamilies": [
 				{
 					"name": "Manrope",
@@ -935,7 +932,8 @@
 					]
 				}
 			]
-		}
+		},
+		"useRootPaddingAwareAlignments": true
 	},
 	"styles": {
 		"color": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
When the font family PR was merged, I missed the conflict with the duplicate typography setting, which ended up breaking the font sizes. "typography" was added both on line 100 and line 158 in theme.json.

This PR removes the duplication.

**Testing Instructions**

Apply the PR and confirm that the correct font size and the correct default font family is used:
Font: Manrope
Body text: --wp--preset--font-size--medium