### PR TITLE
Remove link underline for site title.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 vendor
 *.DS_Store
+.vscode

--- a/theme.json
+++ b/theme.json
@@ -1023,6 +1023,18 @@
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var:preset|font-size|small"
+				},
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
 				}
 			}
 		},

--- a/theme.json
+++ b/theme.json
@@ -36,7 +36,7 @@
 					"slug": "accent-1"
 				},
 				{
-					"color": "#F6CFF4", 
+					"color": "#F6CFF4",
 					"name": "Accent 2",
 					"slug": "accent-2"
 				},
@@ -1011,6 +1011,13 @@
 				"typography": {
 					"fontSize": "var:preset|font-size|medium",
 					"fontWeight": "700"
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
 				}
 			},
 			"core/navigation": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

- Remove the link underline for the site title block.
- Add underline to navigation links on hover.
- Also adding the `.vscode` folder to `.gitignore`

**Screenshots**

https://github.com/user-attachments/assets/17e742eb-04b1-4ef3-acea-ebde7292addd


**Testing Instructions**

1. Go to the site editor.
2. Check the different headers, and confirm that the link on the site title is not underlined.
3. Confirm in the front end.
