### PR TITLE
Fix heading sizes

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1062,12 +1062,12 @@
 			},
 			"h3": {
 				"typography": {
-					"fontSize": "var:preset|font-size|x-large"
+					"fontSize": "38px"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontSize": "var:preset|font-size|large"
+					"fontSize": "28px"
 				}
 			},
 			"h5": {

--- a/theme.json
+++ b/theme.json
@@ -1010,7 +1010,8 @@
 			"core/site-title": {
 				"typography": {
 					"fontSize": "var:preset|font-size|medium",
-					"fontWeight": "700"
+					"fontWeight": "700",
+					"letterSpacing": "-.5px"
 				},
 				"elements": {
 					"link": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

It is related to https://github.com/WordPress/twentytwentyfive/issues/36. I'm setting the heading sizes in the `theme.json` file to match the figma library.

I am also adding a negative letter spacing to the site title block.

<!-- Describe the purpose or reason for the pull request -->

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

https://github.com/user-attachments/assets/21bf2179-f0a5-411b-9147-52f3fc4a7f5d

**Testing Instructions**

1. Create a page.
2. Add the different headings.
3. Confirm that they match the sizes of the figma library.
