### PR TITLE
Theme.json: Update some text and link colors 

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -942,6 +942,16 @@
 				}
 			},
 			"core/post-date": {
+				"color":{
+					"text": "var:preset|color|primary"
+				},
+				"elements": {
+					"link": {
+						"color"	: {
+							"text": "var:preset|color|primary"
+						}
+					}
+				},
 				"typography": {
 					"fontSize": "var:preset|font-size|small"
 				}
@@ -982,6 +992,11 @@
 							}
 						}
 					}
+				}
+			},
+			"core/term-description": {
+				"color":{
+					"text": "var:preset|color|primary"
 				}
 			},
 			"core/navigation": {

--- a/theme.json
+++ b/theme.json
@@ -1052,6 +1052,11 @@
 					"fontWeight": "400",
 					"lineHeight": "1.125"
 				}
+			},
+			"link": {
+				"color": {
+					"text": "var:preset|color|contrast"
+				}
 			}
 		}
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This PR:

- Sets the default link color to "contrast".  It does not set different color for non-default link states like _visited_.
- Sets the post date text color and link color to "primary".
This color can be seen here: https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=559-1943&t=PJROpHtiReAh54XJ-4
- Sets the term description text color to "primary"
This color can be seen here: https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=559-1895&t=PJROpHtiReAh54XJ-4

**Screenshots**

Before, the browser default link colors are used:
![link-color-before](https://github.com/user-attachments/assets/8f264fc1-5b4a-421b-8481-2d4be45511f6)

After:
![links-after](https://github.com/user-attachments/assets/537c6774-b6ec-4d2d-a1da-f32f3a0823f4)

![links-and-text-after](https://github.com/user-attachments/assets/81ef4dae-0fce-4f4f-8ebc-8dfc20687110)


**Testing Instructions**

Apply the PR and add the following blocks:
A paragraph with a link.
Two post date blocks, one with link and one without.
A term description block.

Confirm that the colors match the design.
