### PR TITLE
Update the value of the opacity-20 color in the default palette

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -26,7 +26,7 @@
 					"slug": "secondary"
 				},
 				{
-					"color": "#FFFFFF33",
+					"color": "#11111133",
 					"name": "Opacity 20%",
 					"slug": "opacity-20"
 				},


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

The opacity-20 color in the default palette is invisible on the light background color. 
This PR changes the color to `#11111133`

**Screenshots**

<!-- Add screenshots of the change, if applicable -->
This is the search form that is used in the 404 template, before this PR:
![search-before](https://github.com/user-attachments/assets/221bf9b2-a99b-4932-95c1-0d4eee863980)

And after:
![image](https://github.com/user-attachments/assets/ff57dc79-3364-4ad4-a285-0e3f43206068)

**Testing Instructions**
Add the opacity-20 color to any block with color options, and confirm that the color matches the design:
https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=3142-1003&t=qPCNUklO1LoimmSd-4
