### PR TITLE
Claim copyright for contributors.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -17,7 +17,7 @@ Twenty Twenty-Five emphasizes simplicity and adaptability. It offers flexible de
 
 == Copyright ==
 
-Twenty Twenty-Five WordPress Theme, (C) 2024 WordPress.org
+Twenty Twenty-Five WordPress Theme, (C) 2024 WordPress.org and contributors.
 Twenty Twenty-Five is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
**Description**

 One of the benefits of contributing to WordPress is that contributors license their code under the GPL rather than assign copyright to the WordPress Foundation or another entity.

As such, the bundled theme licenses ought to include a copyright claim for contributors similar to that in the main WordPress license.txt file.

**Screenshots**

N/A

**Testing Instructions**

N/A