### PR TITLE
Personal blog: Misc width changes

### DIFF
--- a/patterns/post-navigation.php
+++ b/patterns/post-navigation.php
@@ -12,10 +12,10 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50"},"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"default"}} -->
-<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-	<!-- wp:group {"ariaLabel":"Post navigation","tagName":"nav","align":"full","style":{"border":{"top":{"color":"var:preset|color|opacity-20","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<nav class="wp-block-group alignfull" aria-label="Post navigation" style="border-top-color:var(--wp--preset--color--opacity-20);border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
+<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60);">
+	<!-- wp:group {"ariaLabel":"Post navigation","tagName":"nav","align":"wide","style":{"border":{"top":{"color":"var:preset|color|opacity-20","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<nav class="wp-block-group alignwide" aria-label="Post navigation" style="border-top-color:var(--wp--preset--color--opacity-20);border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
 		<!-- wp:post-navigation-link {"type":"previous","showTitle":true,"arrow":"arrow"} /-->
 		<!-- wp:post-navigation-link {"showTitle":true,"arrow":"arrow"} /-->
 	</nav>

--- a/patterns/posts-personal-blog.php
+++ b/patterns/posts-personal-blog.php
@@ -31,9 +31,9 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
-	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
-	<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-		<!-- wp:query-pagination {"paginationArrow":"arrow","align":"full","layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignwide">
+		<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
 			<!-- wp:query-pagination-previous /-->
 			<!-- wp:query-pagination-numbers /-->
 			<!-- wp:query-pagination-next /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -25,16 +25,7 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50"},"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"default"}} -->
-		<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-			<!-- wp:group {"ariaLabel":"Posts navigation","tagName":"nav","align":"full","style":{"border":{"top":{"color":"var:preset|color|contrast","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-			<nav class="wp-block-group alignfull" aria-label="Posts navigation" style="border-top-color:var(--wp--preset--color--contrast);border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
-				<!-- wp:post-navigation-link {"type":"previous","showTitle":true,"arrow":"arrow"} /-->
-				<!-- wp:post-navigation-link {"showTitle":true,"arrow":"arrow"} /-->
-			</nav>
-			<!-- /wp:group -->
-		</div>
-		<!-- /wp:group -->
+		<!-- wp:pattern {"slug":"twentytwentyfive/post-navigation"} /-->
 
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
After the change to the width of the header and footer, some elements in the default templates have the wrong width.

**Screenshots**
Query pagination before:
![pagination-before](https://github.com/user-attachments/assets/1fafb9d1-d23a-41d3-9f2c-d2f1a62f67fc)

Query pagination after:
![pagination-after](https://github.com/user-attachments/assets/d4bdd4b9-c171-4642-b103-224608aa50f3)

Post navigation (next and previous post link) before:
![post-nav-before](https://github.com/user-attachments/assets/6c1a5564-058e-41ec-bfc1-c84cf97bb756)

Post navigation (next and previous post link) after:
![post-nav-after](https://github.com/user-attachments/assets/c3b733ad-4c71-4c6e-afa7-a2790629f3e5)

( I had to use the zoom on the browser to take these shots, I hope that does not distort them too much)

**Testing Instructions**
On your WordPress test installation, create a new post with a default width group block, a wide, and full width group block.
Make sure that your test installation has enough posts to test the query pagination and the next and previous posts navigation.
In the admin area, set the reading setting to show the latest posts on the home page.

On the front: View the homepage and confirm that default, wide, and full width blocks display correctly.
Confirm that the query pagination aligns with the wide width, the site header, and site footer.

On the front: Go to the post you created that has the blocks with the different widths.
Confirm that the next and previous posts links align with the wide width, site header, and site footer.
