### PR TITLE
Try: Add 3 section styles, update Hero: Centered Heading pattern.

### DIFF
--- a/patterns/contact-location-and-link.php
+++ b/patterns/contact-location-and-link.php
@@ -11,8 +11,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"backgroundColor":"accent-1","layout":{"type":"constrained","justifyContent":"center"}} -->
-<div class="wp-block-group alignfull has-accent-1-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
+<!-- wp:group {"align":"full","className":"is-style-section-3","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
+<div class="wp-block-group alignfull is-style-section-3" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|40","left":"var:preset|spacing|50"}}}} -->
 	<div class="wp-block-columns alignwide">
 		<!-- wp:column {"verticalAlignment":"top","width":""} -->
@@ -39,5 +39,5 @@
 		<!-- /wp:column -->
 		</div>
 	<!-- /wp:columns -->
-	</div>
+</div>
 <!-- /wp:group -->

--- a/patterns/hero-centered-heading.php
+++ b/patterns/hero-centered-heading.php
@@ -15,8 +15,8 @@
 <div class="wp-block-group alignfull" style="min-height:0vh;margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--40);">
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
-		<!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"right":"0","left":"0"},"padding":{"right":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast"} -->
-		<h1 class="wp-block-heading has-text-align-center has-contrast-color has-text-color has-link-color" style="margin-right:0;margin-left:0;padding-right:0;padding-left:0">Tell your story</h1>
+		<!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"right":"0","left":"0"},"padding":{"right":"0","left":"0"}}}} -->
+		<h1 class="wp-block-heading has-text-align-center" style="margin-right:0;margin-left:0;padding-right:0;padding-left:0">Tell your story</h1>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center"} -->

--- a/patterns/two-headings-and-a-list.php
+++ b/patterns/two-headings-and-a-list.php
@@ -27,8 +27,8 @@
 
 		<!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
-			<!-- wp:heading {"level":4,"style":{"typography":{"textTransform":"uppercase"}},"textColor":"primary","fontSize":"small"} -->
-			<h4 class="wp-block-heading has-primary-color has-text-color has-small-font-size" style="text-transform:uppercase"><?php esc_html_e( 'What will happen at “Stories, historias, iсторії, iστορίες”:', 'twentytwentyfive' ); ?></h4>
+			<!-- wp:heading {"level":4,"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
+			<h4 class="wp-block-heading has-small-font-size" style="text-transform:uppercase"><?php esc_html_e( 'What will happen at “Stories, historias, iсторії, iστορίες”:', 'twentytwentyfive' ); ?></h4>
 			<!-- /wp:heading -->
 
 			<!-- wp:list {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"fontSize":"small"} -->

--- a/styles/blocks/section-1.json
+++ b/styles/blocks/section-1.json
@@ -26,6 +26,11 @@
 					"background": "var(--wp--preset--color--contrast)",
 					"text": "var(--wp--preset--color--base)"
 				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--contrast)"
+				}
 			}
 		}
 	}

--- a/styles/blocks/section-1.json
+++ b/styles/blocks/section-1.json
@@ -1,0 +1,32 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"slug": "section-1",
+	"title": "Style 1",
+	"blockTypes": [
+		"core/group",
+		"core/columns",
+		"core/column"
+	],
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--accent-2)",
+			"text": "var(--wp--preset--color--contrast)"
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "color-mix(in srgb, currentColor 25%, transparent)"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--contrast)",
+					"text": "var(--wp--preset--color--base)"
+				}
+			}
+		}
+	}
+}

--- a/styles/blocks/section-2.json
+++ b/styles/blocks/section-2.json
@@ -1,0 +1,32 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"slug": "section-2",
+	"title": "Style 2",
+	"blockTypes": [
+		"core/group",
+		"core/columns",
+		"core/column"
+	],
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--accent-3)",
+			"text": "var(--wp--preset--color--accent-2)"
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "color-mix(in srgb, currentColor 25%, transparent)"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--contrast)",
+					"text": "var(--wp--preset--color--base)"
+				}
+			}
+		}
+	}
+}

--- a/styles/blocks/section-2.json
+++ b/styles/blocks/section-2.json
@@ -26,6 +26,11 @@
 					"background": "var(--wp--preset--color--contrast)",
 					"text": "var(--wp--preset--color--base)"
 				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--accent-2)"
+				}
 			}
 		}
 	}

--- a/styles/blocks/section-3.json
+++ b/styles/blocks/section-3.json
@@ -26,6 +26,11 @@
 					"background": "var(--wp--preset--color--contrast)",
 					"text": "var(--wp--preset--color--base)"
 				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--contrast)"
+				}
 			}
 		}
 	}

--- a/styles/blocks/section-3.json
+++ b/styles/blocks/section-3.json
@@ -1,0 +1,32 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"slug": "section-3",
+	"title": "Style 3",
+	"blockTypes": [
+		"core/group",
+		"core/columns",
+		"core/column"
+	],
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--accent-1)",
+			"text": "var(--wp--preset--color--contrast)"
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "color-mix(in srgb, currentColor 25%, transparent)"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--contrast)",
+					"text": "var(--wp--preset--color--base)"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
**Description**

Starts initial work on adding Section styles (#142). In this case, it adds three section styles from [this spot in the Figma file](https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=77-258&t=0tJE2VXhthA9HmZK-1):

![Screenshot 2024-08-29 at 11 53 00](https://github.com/user-attachments/assets/002c9405-e16a-4a30-9ec1-8d0b271a87a2)

These use what I believe is the [most suggested format for section style slugs](https://github.com/WordPress/twentytwentyfive/issues/3#issuecomment-2200847735) (#3), `section-1`, `section-2`, `section-3`.

Additionally, I made a change to the Hero Centered Heading pattern to remove the explicitly set heading color, so that it will inherit the color set on the container instead.

**Screenshots**

![section styles](https://github.com/user-attachments/assets/a52e6063-bcc8-4d31-8575-d3a5ef4765d9)

**Testing Instructions**

1. Open the inserter, insert 4 instances of the Hero Centered Heading pattern.
2. Set the 2nd to fourth pattern to styles 2-4 in the inspector.
3. Test additional patterns (group/column based) for these section styles.