### PR TITLE
Try: Reduce spacing presets to use 1-click controls

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -55,11 +55,6 @@
 			"defaultSpacingSizes": false,
 			"spacingSizes": [
 				{
-					"name": "X-Tiny",
-					"size": "5px",
-					"slug": "10"
-				},
-				{
 					"name": "Tiny",
 					"size": "10px",
 					"slug": "20"
@@ -143,21 +138,12 @@
 				},
 				{
 					"fluid": {
-						"max": "3rem",
-						"min": "2.375rem"
-					},
-					"name": "Extra Large",
-					"size": "3rem",
-					"slug": "x-large"
-				},
-				{
-					"fluid": {
 						"max": "3.625rem",
 						"min": "2.625rem"
 					},
-					"name": "Extra Extra Large",
+					"name": "Extra Large",
 					"size": "2.625rem",
-					"slug": "xx-large"
+					"slug": "x-large"
 				}
 			],
 			"fontFamilies": [


### PR DESCRIPTION
**Description**

Fixes #152. Eliminates one preset from both spacing and typography preset arrays, so that they use the 1-click controls rather than the extended dropdown controls:

![Screenshot 2024-08-29 at 12 36 13](https://github.com/user-attachments/assets/6f40e6d7-0226-4034-b922-f5e28ab4e30d)

Specifically this removes the X-Tiny (5px) preset, and it removes the X-Large preset and changes the XX-Large preset to take its place. 

That's a test to see how it feels out, please take a look and I'll update the PR accordingly.

**Testing Instructions**

1. Open a page or post
2. Type some text, observe the inspector that it has the 1-click segmented control font size picker.
3. Add a padding control from the ToolsPanel, observe that it has the 1-click range control for spacing presets.