### PR TITLE
Single template: Replace reference to Tiny spacing with 5px

### DIFF
--- a/templates/single.html
+++ b/templates/single.html
@@ -8,7 +8,7 @@
 		<!-- wp:post-title {"level":1,"fontSize":"x-large"} /-->
 		<!-- wp:post-featured-image {"aspectRatio":"3/2"} /-->
 
-		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10","margin":{"bottom":"var:preset|spacing|60"}}},"fontSize":"x-small","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"5px","margin":{"bottom":"var:preset|spacing|60"}}},"fontSize":"x-small","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group has-x-small-font-size" style="margin-bottom:var(--wp--preset--spacing--60)">
 			<!-- wp:paragraph {"textColor":"primary"} -->
 			<p class="has-primary-color has-text-color">Written by </p>


### PR DESCRIPTION
**Description**

Followup to #153. Removes the one place where the "Tiny" spacing preset was used, and replaces it with a hardcoded value.

**Screenshots**

![Screenshot 2024-08-29 at 14 35 23](https://github.com/user-attachments/assets/86d268cf-3a0e-4325-9519-2f44575826c3)

**Testing Instructions**

1. Open the site editor.
2. Navigate to the Single template.
3. Observe the "Written by" byline having a 5px space between text and author.