### PR TITLE
Try: Add comments.

### DIFF
--- a/patterns/comments.php
+++ b/patterns/comments.php
@@ -1,8 +1,10 @@
 <?php
 /**
  * Title: Comments
- * Slug: twentytwentyfive/hidden-comments
- * Inserter: no
+ * Slug: twentytwentyfive/comments
+ * Description: Comments area with comments list, pagination, and comment form.
+ * Categories: text
+ * Block Types: core/comments
  *
  * @package WordPress
  * @subpackage Twenty_Twenty_Five
@@ -12,10 +14,10 @@
 ?>
 <!-- wp:comments {"className":"wp-block-comments-query-loop","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}}} -->
 <div class="wp-block-comments wp-block-comments-query-loop" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
-	<!-- wp:heading -->
-	<h4><?php esc_html_e( 'Comments', 'twentytwentyfive' ); ?></h4>
+	<!-- wp:heading {"fontSize":"x-large"} -->
+	<h2 class="wp-block-heading has-x-large-font-size">Comments</h2>
 	<!-- /wp:heading -->
-	<!-- wp:comments-title {"level":4} /-->
+	<!-- wp:comments-title {"level":3,"fontSize":"large"} /-->
 	<!-- wp:comment-template -->
 	<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
 	<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">

--- a/patterns/hidden-comments.php
+++ b/patterns/hidden-comments.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Title: Comments
+ * Slug: twentytwentyfive/hidden-comments
+ * Inserter: no
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+<!-- wp:comments {"className":"wp-block-comments-query-loop","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}}} -->
+<div class="wp-block-comments wp-block-comments-query-loop" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
+	<!-- wp:heading -->
+	<h4><?php esc_html_e( 'Comments', 'twentytwentyfive' ); ?></h4>
+	<!-- /wp:heading -->
+	<!-- wp:comments-title {"level":4} /-->
+	<!-- wp:comment-template -->
+	<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
+	<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
+		<div class="wp-block-group">
+			<!-- wp:avatar {"size":50} /-->
+			<!-- wp:group -->
+			<div class="wp-block-group">
+				<!-- wp:comment-date /-->
+				<!-- wp:comment-author-name /-->
+				<!-- wp:comment-content /-->
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+				<div class="wp-block-group">
+					<!-- wp:comment-edit-link /-->
+					<!-- wp:comment-reply-link /-->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+	<!-- /wp:comment-template -->
+
+	<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<!-- wp:comments-pagination-previous /-->
+	<!-- wp:comments-pagination-next /-->
+	<!-- /wp:comments-pagination -->
+
+	<!-- wp:post-comments-form /-->
+</div>
+<!-- /wp:comments -->

--- a/templates/single.html
+++ b/templates/single.html
@@ -22,6 +22,7 @@
 		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 			<!-- wp:post-terms {"term":"post_tag","separator":"  ","className":"is-style-post-terms-1"} /-->
+			 <!-- wp:pattern {"slug":"twentytwentyfive/hidden-comments"} /-->
 		</div>
 		<!-- /wp:group -->
 

--- a/templates/single.html
+++ b/templates/single.html
@@ -22,7 +22,7 @@
 		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 			<!-- wp:post-terms {"term":"post_tag","separator":"  ","className":"is-style-post-terms-1"} /-->
-			 <!-- wp:pattern {"slug":"twentytwentyfive/hidden-comments"} /-->
+			 <!-- wp:pattern {"slug":"twentytwentyfive/comments"} /-->
 		</div>
 		<!-- /wp:group -->
 

--- a/theme.json
+++ b/theme.json
@@ -1036,7 +1036,7 @@
 				}
 			},
 			"core/post-comments-form": {
-				"css": "& textarea, input:not([type=submit]){border-radius:.25rem; border-color: var(--wp--preset--color--opacity-20) !important;} & input[type=checkbox]{margin:0 .2rem 0 0 !important;} & label {font-size: var(--wp--preset--font-size--x-small); }",
+				"css": "& textarea, input:not([type=submit]){border-radius:.25rem; border-color: var(--wp--preset--color--opacity-20) !important;} & input[type=checkbox]{margin:0 .2rem 0 0 !important;} & label {font-size: var(--wp--preset--font-size--small); }",
 				"typography": {
 					"fontSize": "var:preset|font-size|medium"
 				},

--- a/theme.json
+++ b/theme.json
@@ -975,7 +975,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "var:preset|font-size|x-small",
+					"fontSize": "var:preset|font-size|small",
 					"fontStyle": "normal"
 				},
 				"spacing": {
@@ -987,7 +987,7 @@
 			},
 			"core/comment-content": {
 				"typography": {
-					"fontSize": "var:preset|font-size|small"
+					"fontSize": "var:preset|font-size|medium"
 				},
 				"spacing": {
 					"margin": {
@@ -998,7 +998,7 @@
 			},
 			"core/comment-date": {
 				"typography": {
-					"fontSize": "var:preset|font-size|x-small"
+					"fontSize": "var:preset|font-size|small"
 				},
 				"color": {
 					"text": "var:preset|color|contrast"
@@ -1020,7 +1020,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "var:preset|font-size|x-small"
+					"fontSize": "var:preset|font-size|small"
 				}
 			},
 			"core/comment-reply-link": {
@@ -1032,13 +1032,13 @@
 					}
 				},
 				"typography": {
-					"fontSize": "var:preset|font-size|x-small"
+					"fontSize": "var:preset|font-size|small"
 				}
 			},
 			"core/post-comments-form": {
 				"css": "& textarea, input:not([type=submit]){border-radius:.25rem; border-color: var(--wp--preset--color--opacity-20) !important;} & input[type=checkbox]{margin:0 .2rem 0 0 !important;} & label {font-size: var(--wp--preset--font-size--x-small); }",
 				"typography": {
-					"fontSize": "var:preset|font-size|small"
+					"fontSize": "var:preset|font-size|medium"
 				},
 				"spacing": {
 					"padding": {
@@ -1049,7 +1049,7 @@
 			},
 			"core/comments-pagination": {
 				"typography": {
-					"fontSize": "var:preset|font-size|small"
+					"fontSize": "var:preset|font-size|medium"
 				},
 				"spacing": {
 					"margin": {
@@ -1060,17 +1060,17 @@
 			},
 			"core/comments-pagination-next": {
 				"typography": {
-					"fontSize": "var:preset|font-size|small"
+					"fontSize": "var:preset|font-size|medium"
 				}
 			},
 			"core/comments-pagination-numbers": {
 				"typography": {
-					"fontSize": "var:preset|font-size|small"
+					"fontSize": "var:preset|font-size|medium"
 				}
 			},
 			"core/comments-pagination-previous": {
 				"typography": {
-					"fontSize": "var:preset|font-size|small"
+					"fontSize": "var:preset|font-size|medium"
 				}
 			},
 			"core/post-date": {
@@ -1215,7 +1215,7 @@
 		"elements": {
 			"button": {
 				"typography": {
-					"fontSize": "var:preset|font-size|small"
+					"fontSize": "var:preset|font-size|medium"
 				},
 				"color": {
 					"background": "var:preset|color|contrast",

--- a/theme.json
+++ b/theme.json
@@ -931,6 +931,11 @@
 			"lineHeight": "1.4"
 		},
 		"blocks": {
+			"core/avatar": {
+				"border": {
+					"radius": "100px"
+				}
+			},
 			"core/code": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|fira-code",
@@ -943,29 +948,127 @@
 				},
 				"spacing": {
 					"padding": {
-						"right": "var(--wp--preset--spacing--40)",
-						"bottom": "var(--wp--preset--spacing--40)",
-						"left": "var(--wp--preset--spacing--40)",
-						"top": "var(--wp--preset--spacing--40)"
+						"right": "var:preset|spacing|40",
+						"bottom": "var:preset|spacing|40",
+						"left": "var:preset|spacing|40",
+						"top": "var:preset|spacing|40"
 					}
 				}
 			},
 			"core/comment-author-name": {
+				"color": {
+					"text": "var:preset|color|primary"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var:preset|color|primary"
+						},
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "var:preset|font-size|x-small",
+					"fontStyle": "normal"
+				},
+				"spacing": {
+					"margin": {
+						"top": "5px",
+						"bottom": "0px"
+					}
+				}
+			},
+			"core/comment-content": {
 				"typography": {
 					"fontSize": "var:preset|font-size|small"
+				},
+				"spacing": {
+					"margin": {
+						"top": "var:preset|spacing|30",
+						"bottom": "var:preset|spacing|30"
+					}
 				}
 			},
 			"core/comment-date": {
 				"typography": {
-					"fontSize": "var:preset|font-size|small"
+					"fontSize": "var:preset|font-size|x-small"
+				},
+				"color": {
+					"text": "var:preset|color|contrast"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var:preset|color|contrast"
+						}
+					}
 				}
 			},
 			"core/comment-edit-link": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var:preset|color|contrast"
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "var:preset|font-size|x-small"
+				}
+			},
+			"core/comment-reply-link": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var:preset|color|contrast"
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "var:preset|font-size|x-small"
+				}
+			},
+			"core/post-comments-form": {
+				"css": "& textarea, input:not([type=submit]){border-radius:.25rem; border-color: var(--wp--preset--color--opacity-20) !important;} & input[type=checkbox]{margin:0 .2rem 0 0 !important;} & label {font-size: var(--wp--preset--font-size--x-small); }",
+				"typography": {
+					"fontSize": "var:preset|font-size|small"
+				},
+				"spacing": {
+					"padding": {
+						"top": "var:preset|spacing|40",
+						"bottom": "var:preset|spacing|40"
+					}
+				}
+			},
+			"core/comments-pagination": {
+				"typography": {
+					"fontSize": "var:preset|font-size|small"
+				},
+				"spacing": {
+					"margin": {
+						"top": "var:preset|spacing|40",
+						"bottom": "var:preset|spacing|40"
+					}
+				}
+			},
+			"core/comments-pagination-next": {
 				"typography": {
 					"fontSize": "var:preset|font-size|small"
 				}
 			},
-			"core/comment-reply-link": {
+			"core/comments-pagination-numbers": {
+				"typography": {
+					"fontSize": "var:preset|font-size|small"
+				}
+			},
+			"core/comments-pagination-previous": {
 				"typography": {
 					"fontSize": "var:preset|font-size|small"
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Fixes https://github.com/WordPress/twentytwentyfive/issues/115

- Adding comments configuration to `theme.json`
- Adding comments hidden pattern.
- Including comments in the single template.

🗒️ Notes

1. I set some `5px` values now that we no longer have that as a preset.
2. I had to set some custom CSS to override the default styles of the form inputs.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

https://github.com/user-attachments/assets/4609b696-7e14-4fe7-8518-0af52a333667


**Testing Instructions**

1. Create a post, be sure that the template is using the comments.
3. Leave as many comments as you like.
4. Confirm that the implementation looks like [the designs](https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=3326-2103&t=iVc8k2Kl9C1qrITw-1)
