### PR TITLE
Try: Update font-size slugs+names to match T-shirt sizes.

### DIFF
--- a/patterns/contact-centered-social-link.php
+++ b/patterns/contact-centered-social-link.php
@@ -13,8 +13,8 @@
 ?>
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"},"blockGap":"var:preset|spacing|50"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)">
-	<!-- wp:paragraph {"align":"center","fontSize":"x-large"} -->
-	<p class="has-text-align-center has-x-large-font-size"><?php echo wp_kses_post( _x( 'Got questions? <br><a href="#" rel="nofollow">Feel free to reach out.</a>', 'Heading of the Contact social link pattern', 'twentytwentyfive' ) ); ?></p>
+	<!-- wp:paragraph {"align":"center","fontSize":"xx-large"} -->
+	<p class="has-text-align-center has-xx-large-font-size"><?php echo wp_kses_post( _x( 'Got questions? <br><a href="#" rel="nofollow">Feel free to reach out.</a>', 'Heading of the Contact social link pattern', 'twentytwentyfive' ) ); ?></p>
 	<!-- /wp:paragraph -->
 
 	<!-- wp:social-links {"iconColor":"contrast","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"center"}} -->

--- a/patterns/contact-location-and-link.php
+++ b/patterns/contact-location-and-link.php
@@ -23,7 +23,7 @@
 				<h3 class="wp-block-heading">Visit us at 123 Example St. Manhattan, NY 10300, United States</h3>
 				<!-- /wp:heading -->
 
-				<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
+				<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} -->
 				<p class="has-small-font-size" style="text-transform:uppercase"><a href="#">Get directions</a></p>
 				<!-- /wp:paragraph -->
 			</div>

--- a/patterns/footer-centered.php
+++ b/patterns/footer-centered.php
@@ -21,7 +21,7 @@
 		<!-- wp:spacer {"height":"20px"} -->
 		<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:paragraph {"align":"center","fontSize":"x-small"} -->
+		<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 		<p class="has-text-align-center has-x-small-font-size">Designed with <strong>WordPress</strong></p>
 		<!-- /wp:paragraph -->
 	</div>

--- a/patterns/footer-centered.php
+++ b/patterns/footer-centered.php
@@ -22,7 +22,7 @@
 		<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 		<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-		<p class="has-text-align-center has-x-small-font-size">Designed with <strong>WordPress</strong></p>
+		<p class="has-text-align-center has-small-font-size">Designed with <strong>WordPress</strong></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/patterns/footer-columns.php
+++ b/patterns/footer-columns.php
@@ -29,7 +29,7 @@
 				<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"constrained"}} -->
 				<div class="wp-block-group" style="padding-right:0;padding-left:0">
 					<!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium"} -->
-					<h3 class="wp-block-heading has-small-font-size" style="font-style:normal;font-weight:700">Stories</h3>
+					<h3 class="wp-block-heading has-medium-font-size" style="font-style:normal;font-weight:700">Stories</h3>
 					<!-- /wp:heading -->
 					<!-- wp:navigation {"overlayMenu":"never","fontSize":"medium","layout":{"type":"flex","orientation":"vertical"},"ariaLabel":"<?php esc_attr_e( 'Stories', 'twentytwentyfive' ); ?>"} -->
 						<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Blog', 'twentytwentyfive' ); ?>","url":"#"} /-->

--- a/patterns/footer-columns.php
+++ b/patterns/footer-columns.php
@@ -20,7 +20,7 @@
 		<div class="wp-block-group alignfull">
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20","padding":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"constrained"}} -->
 			<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
-				<!-- wp:site-title {"level":2,"fontSize":"xxx-large"} /-->
+				<!-- wp:site-title {"level":2,"fontSize":"xx-large"} /-->
 				<!-- wp:site-tagline /-->
 			</div>
 			<!-- /wp:group -->

--- a/patterns/footer-columns.php
+++ b/patterns/footer-columns.php
@@ -12,8 +12,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull">
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
 		<!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"top"}} -->

--- a/patterns/footer-columns.php
+++ b/patterns/footer-columns.php
@@ -20,7 +20,7 @@
 		<div class="wp-block-group alignfull">
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20","padding":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"constrained"}} -->
 			<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
-				<!-- wp:site-title {"level":2,"fontSize":"xx-large"} /-->
+				<!-- wp:site-title {"level":2,"fontSize":"xxx-large"} /-->
 				<!-- wp:site-tagline /-->
 			</div>
 			<!-- /wp:group -->
@@ -28,10 +28,10 @@
 			<div class="wp-block-group">
 				<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"constrained"}} -->
 				<div class="wp-block-group" style="padding-right:0;padding-left:0">
-					<!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
+					<!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium"} -->
 					<h3 class="wp-block-heading has-small-font-size" style="font-style:normal;font-weight:700">Stories</h3>
 					<!-- /wp:heading -->
-					<!-- wp:navigation {"overlayMenu":"never","fontSize":"small","layout":{"type":"flex","orientation":"vertical"},"ariaLabel":"<?php esc_attr_e( 'Stories', 'twentytwentyfive' ); ?>"} -->
+					<!-- wp:navigation {"overlayMenu":"never","fontSize":"medium","layout":{"type":"flex","orientation":"vertical"},"ariaLabel":"<?php esc_attr_e( 'Stories', 'twentytwentyfive' ); ?>"} -->
 						<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Blog', 'twentytwentyfive' ); ?>","url":"#"} /-->
 						<!-- wp:navigation-link {"label":"<?php esc_html_e( 'About', 'twentytwentyfive' ); ?>","url":"#"} /-->
 						<!-- wp:navigation-link {"label":"<?php esc_html_e( 'FAQs', 'twentytwentyfive' ); ?>","url":"#"} /-->
@@ -41,10 +41,10 @@
 				<!-- /wp:group -->
 				<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"constrained"}} -->
 				<div class="wp-block-group" style="padding-right:0;padding-left:0">
-					<!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"small"} -->
+					<!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium"} -->
 					<h3 class="wp-block-heading has-small-font-size" style="font-style:normal;font-weight:700">Featured</h3>
 					<!-- /wp:heading -->
-					<!-- wp:navigation {"overlayMenu":"never","fontSize":"small","layout":{"type":"flex","orientation":"vertical"},"ariaLabel":"<?php esc_attr_e( 'Featured', 'twentytwentyfive' ); ?>"} -->
+					<!-- wp:navigation {"overlayMenu":"never","fontSize":"medium","layout":{"type":"flex","orientation":"vertical"},"ariaLabel":"<?php esc_attr_e( 'Featured', 'twentytwentyfive' ); ?>"} -->
 						<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Example.com', 'twentytwentyfive' ); ?>","url":"#"} /-->
 						<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Shop', 'twentytwentyfive' ); ?>","url":"#"} /-->
 						<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Patterns', 'twentytwentyfive' ); ?>","url":"#"} /-->
@@ -63,8 +63,8 @@
 
 		<!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 		<div class="wp-block-group alignfull">
-			<!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-small"} /-->
-			<!-- wp:paragraph {"fontSize":"x-small"} -->
+			<!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} /-->
+			<!-- wp:paragraph {"fontSize":"small"} -->
 			<p class="has-x-small-font-size">Designed with <strong>WordPress</strong></p>
 			<!-- /wp:paragraph -->
 		</div>

--- a/patterns/footer-columns.php
+++ b/patterns/footer-columns.php
@@ -12,8 +12,8 @@
  */
 
 ?>
-<!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group">
+<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
 		<!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"top"}} -->
@@ -65,7 +65,7 @@
 		<div class="wp-block-group alignfull">
 			<!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} /-->
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-x-small-font-size">Designed with <strong>WordPress</strong></p>
+			<p class="has-small-font-size">Designed with <strong>WordPress</strong></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/footer-columns.php
+++ b/patterns/footer-columns.php
@@ -42,7 +42,7 @@
 				<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"constrained"}} -->
 				<div class="wp-block-group" style="padding-right:0;padding-left:0">
 					<!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"medium"} -->
-					<h3 class="wp-block-heading has-small-font-size" style="font-style:normal;font-weight:700">Featured</h3>
+					<h3 class="wp-block-heading has-medium-font-size" style="font-style:normal;font-weight:700">Featured</h3>
 					<!-- /wp:heading -->
 					<!-- wp:navigation {"overlayMenu":"never","fontSize":"medium","layout":{"type":"flex","orientation":"vertical"},"ariaLabel":"<?php esc_attr_e( 'Featured', 'twentytwentyfive' ); ?>"} -->
 						<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Example.com', 'twentytwentyfive' ); ?>","url":"#"} /-->

--- a/patterns/footer-newsletter.php
+++ b/patterns/footer-newsletter.php
@@ -12,15 +12,15 @@
  */
 
 ?>
-<!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group">
+<!-- wp:group {"align":"full","className":"is-style-section-3","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-style-section-3">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
 		<!-- wp:site-title {"level":2,"style":{"typography":{"fontSize":"10vw"}}} /-->
 		<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"constrained","justifyContent":"left"}} -->
 		<div class="wp-block-group" style="padding-right:0;padding-left:0">
-			<!-- wp:paragraph {"fontSize":"xx-large"} -->
-			<p class="has-xx-large-font-size">Subscribe to our newsletter</p>
+			<!-- wp:paragraph {"fontSize":"x-large"} -->
+			<p class="has-x-large-font-size">Subscribe to our newsletter</p>
 			<!-- /wp:paragraph -->
 			<!-- wp:buttons -->
 			<div class="wp-block-buttons"><!-- wp:button -->
@@ -36,7 +36,7 @@
 		<div class="wp-block-group alignfull">
 			<!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} /-->
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-x-small-font-size">Designed with <strong>WordPress</strong></p>
+			<p class="has-small-font-size">Designed with <strong>WordPress</strong></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/footer-newsletter.php
+++ b/patterns/footer-newsletter.php
@@ -19,8 +19,8 @@
 		<!-- wp:site-title {"level":2,"style":{"typography":{"fontSize":"10vw"}}} /-->
 		<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"constrained","justifyContent":"left"}} -->
 		<div class="wp-block-group" style="padding-right:0;padding-left:0">
-			<!-- wp:paragraph {"fontSize":"x-large"} -->
-			<p class="has-x-large-font-size">Subscribe to our newsletter</p>
+			<!-- wp:paragraph {"fontSize":"xx-large"} -->
+			<p class="has-xx-large-font-size">Subscribe to our newsletter</p>
 			<!-- /wp:paragraph -->
 			<!-- wp:buttons -->
 			<div class="wp-block-buttons"><!-- wp:button -->
@@ -34,8 +34,8 @@
 		<!-- /wp:spacer -->
 		<!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 		<div class="wp-block-group alignfull">
-			<!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-small"} /-->
-			<!-- wp:paragraph {"fontSize":"x-small"} -->
+			<!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} /-->
+			<!-- wp:paragraph {"fontSize":"small"} -->
 			<p class="has-x-small-font-size">Designed with <strong>WordPress</strong></p>
 			<!-- /wp:paragraph -->
 		</div>

--- a/patterns/footer-social.php
+++ b/patterns/footer-social.php
@@ -16,8 +16,8 @@
 <div class="wp-block-group">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--50)">
-		<!-- wp:site-title {"level":2,"textAlign":"center","style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"400"}},"fontSize":"large"} /-->
-		<!-- wp:navigation {"overlayMenu":"never","style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"400"}},"fontSize":"large","layout":{"type":"flex","justifyContent":"center"},"ariaLabel":"<?php esc_attr_e( 'Social', 'twentytwentyfive' ); ?>"} -->
+		<!-- wp:site-title {"level":2,"textAlign":"center","style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-large"} /-->
+		<!-- wp:navigation {"overlayMenu":"never","style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-large","layout":{"type":"flex","justifyContent":"center"},"ariaLabel":"<?php esc_attr_e( 'Social', 'twentytwentyfive' ); ?>"} -->
 			<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Facebook', 'twentytwentyfive' ); ?>","url":"#"} /-->
 			<!-- wp:navigation-link {"label":"<?php esc_html_e( 'Instagram', 'twentytwentyfive' ); ?>","url":"#"} /-->
 			<!-- wp:navigation-link {"label":"<?php esc_html_e( 'X', 'twentytwentyfive' ); ?>","url":"#"} /-->
@@ -25,7 +25,7 @@
 		<!-- wp:spacer {"height":"20px"} -->
 		<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:paragraph {"align":"center","fontSize":"x-small"} -->
+		<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 		<p class="has-text-align-center has-x-small-font-size">Designed with <strong>WordPress</strong></p>
 		<!-- /wp:paragraph -->
 	</div>

--- a/patterns/footer-social.php
+++ b/patterns/footer-social.php
@@ -26,7 +26,7 @@
 		<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 		<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-		<p class="has-text-align-center has-x-small-font-size">Designed with <strong>WordPress</strong></p>
+		<p class="has-text-align-center has-small-font-size">Designed with <strong>WordPress</strong></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -50,8 +50,8 @@
 
 		<!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 		<div class="wp-block-group alignfull">
-			<!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-small"} /-->
-			<!-- wp:paragraph {"fontSize":"x-small"} -->
+			<!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} /-->
+			<!-- wp:paragraph {"fontSize":"small"} -->
 			<p class="has-x-small-font-size">Designed with <strong>WordPress</strong></p>
 			<!-- /wp:paragraph -->
 		</div>

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -52,7 +52,7 @@
 		<div class="wp-block-group alignfull">
 			<!-- wp:site-title {"level":0,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"small"} /-->
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-x-small-font-size">Designed with <strong>WordPress</strong></p>
+			<p class="has-small-font-size">Designed with <strong>WordPress</strong></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/header-centered.php
+++ b/patterns/header-centered.php
@@ -16,7 +16,7 @@
 <div class="wp-block-group">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--30)">
-		<!-- wp:site-title {"level":0,"textAlign":"center","align":"wide","fontSize":"large"} /-->
+		<!-- wp:site-title {"level":0,"textAlign":"center","align":"wide","fontSize":"x-large"} /-->
 		<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 		<div class="wp-block-group alignwide">
 			<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"center"}} /-->

--- a/patterns/posts-personal-blog.php
+++ b/patterns/posts-personal-blog.php
@@ -25,9 +25,9 @@
 		<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 			<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
-			<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-			<!-- wp:post-content {"align":"full","fontSize":"small","layout":{"type":"constrained"}} /-->
-			<!-- wp:post-date {"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}},"fontSize":"x-small"} /-->
+			<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
+			<!-- wp:post-content {"align":"full","fontSize":"medium","layout":{"type":"constrained"}} /-->
+			<!-- wp:post-date {"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}},"fontSize":"small"} /-->
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->

--- a/patterns/services-three-columns.php
+++ b/patterns/services-three-columns.php
@@ -31,7 +31,7 @@
 			<h4 class="wp-block-heading">Collect</h4>
 			<!-- /wp:heading -->
 
-			<!-- wp:paragraph {"fontSize":"small"} -->
+			<!-- wp:paragraph {"fontSize":"medium"} -->
 			<p class="has-small-font-size">Like flowers that bloom in unexpected places, every story unfolds with beauty and resilience</p>
 			<!-- /wp:paragraph -->
 		</div>
@@ -49,7 +49,7 @@
 			<h4 class="wp-block-heading">Assemble</h4>
 			<!-- /wp:heading -->
 
-			<!-- wp:paragraph {"fontSize":"small"} -->
+			<!-- wp:paragraph {"fontSize":"medium"} -->
 			<p class="has-small-font-size">Like flowers that bloom in unexpected places, every story unfolds with beauty and resilience</p>
 			<!-- /wp:paragraph -->
 		</div>
@@ -67,7 +67,7 @@
 			<h4 class="wp-block-heading">Deliver</h4>
 			<!-- /wp:heading -->
 
-			<!-- wp:paragraph {"fontSize":"small"} -->
+			<!-- wp:paragraph {"fontSize":"medium"} -->
 			<p class="has-small-font-size">Like flowers that bloom in unexpected places, every story unfolds with beauty and resilience</p>
 			<!-- /wp:paragraph -->
 		</div>

--- a/patterns/services-three-columns.php
+++ b/patterns/services-three-columns.php
@@ -50,7 +50,7 @@
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"fontSize":"medium"} -->
-			<p class="has-small-font-size">Like flowers that bloom in unexpected places, every story unfolds with beauty and resilience</p>
+			<p class="has-medium-font-size">Like flowers that bloom in unexpected places, every story unfolds with beauty and resilience</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->

--- a/patterns/services-three-columns.php
+++ b/patterns/services-three-columns.php
@@ -68,7 +68,7 @@
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"fontSize":"medium"} -->
-			<p class="has-small-font-size">Like flowers that bloom in unexpected places, every story unfolds with beauty and resilience</p>
+			<p class="has-medium-font-size">Like flowers that bloom in unexpected places, every story unfolds with beauty and resilience</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->

--- a/patterns/services-three-columns.php
+++ b/patterns/services-three-columns.php
@@ -32,7 +32,7 @@
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"fontSize":"medium"} -->
-			<p class="has-small-font-size">Like flowers that bloom in unexpected places, every story unfolds with beauty and resilience</p>
+			<p class="has-medium-font-size">Like flowers that bloom in unexpected places, every story unfolds with beauty and resilience</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->

--- a/patterns/two-headings-and-a-list.php
+++ b/patterns/two-headings-and-a-list.php
@@ -32,7 +32,7 @@
 			<!-- /wp:heading -->
 
 			<!-- wp:list {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"fontSize":"medium"} -->
-			<ul style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)" class="wp-block-list has-small-font-size">
+			<ul style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)" class="wp-block-list has-medium-font-size">
 				<!-- wp:list-item -->
 				<li><?php esc_html_e( 'Opportunity to learn from master photographers and historians', 'twentytwentyfive' ); ?></li>
 				<!-- /wp:list-item -->

--- a/patterns/two-headings-and-a-list.php
+++ b/patterns/two-headings-and-a-list.php
@@ -28,7 +28,7 @@
 		<!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
 			<!-- wp:heading {"level":4,"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} -->
-			<h4 class="wp-block-heading has-small-font-size" style="text-transform:uppercase"><?php esc_html_e( 'What will happen at “Stories, historias, iсторії, iστορίες”:', 'twentytwentyfive' ); ?></h4>
+			<h4 class="wp-block-heading has-medium-font-size" style="text-transform:uppercase"><?php esc_html_e( 'What will happen at “Stories, historias, iсторії, iστορίες”:', 'twentytwentyfive' ); ?></h4>
 			<!-- /wp:heading -->
 
 			<!-- wp:list {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"fontSize":"medium"} -->

--- a/patterns/two-headings-and-a-list.php
+++ b/patterns/two-headings-and-a-list.php
@@ -27,11 +27,11 @@
 
 		<!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
-			<!-- wp:heading {"level":4,"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} -->
+			<!-- wp:heading {"level":4,"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} -->
 			<h4 class="wp-block-heading has-small-font-size" style="text-transform:uppercase"><?php esc_html_e( 'What will happen at “Stories, historias, iсторії, iστορίες”:', 'twentytwentyfive' ); ?></h4>
 			<!-- /wp:heading -->
 
-			<!-- wp:list {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"fontSize":"small"} -->
+			<!-- wp:list {"style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"fontSize":"medium"} -->
 			<ul style="padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)" class="wp-block-list has-small-font-size">
 				<!-- wp:list-item -->
 				<li><?php esc_html_e( 'Opportunity to learn from master photographers and historians', 'twentytwentyfive' ); ?></li>

--- a/styles/typography/typography-preset-1.json
+++ b/styles/typography/typography-preset-1.json
@@ -23,7 +23,7 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontSize": "var:preset|font-size|xxx-large",
+					"fontSize": "var:preset|font-size|xx-large",
 					"fontWeight": "500",
 					"letterSpacing": "-1.16px"
 				}

--- a/styles/typography/typography-preset-1.json
+++ b/styles/typography/typography-preset-1.json
@@ -23,7 +23,7 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontSize": "var:preset|font-size|xx-large",
+					"fontSize": "var:preset|font-size|xxx-large",
 					"fontWeight": "500",
 					"letterSpacing": "-1.16px"
 				}

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,8 +2,8 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
-	<!-- wp:heading {"level":1,"fontSize":"x-large"} -->
-	<h1 class="wp-block-heading has-x-large-font-size">Blog</h1>
+	<!-- wp:heading {"level":1,"fontSize":"xx-large"} -->
+	<h1 class="wp-block-heading has-xx-large-font-size">Blog</h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,8 +2,8 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
-	<!-- wp:heading {"level":1,"fontSize":"x-large"} -->
-	<h1 class="wp-block-heading has-x-large-font-size">Blog</h1>
+	<!-- wp:heading {"level":1,"fontSize":"xx-large"} -->
+	<h1 class="wp-block-heading has-xx-large-font-size">Blog</h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->

--- a/templates/page.html
+++ b/templates/page.html
@@ -5,7 +5,7 @@
 	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 		<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} /-->
-		<!-- wp:post-title {"level":1,"fontSize":"x-large"} /-->
+		<!-- wp:post-title {"level":1,"fontSize":"xx-large"} /-->
 		<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
 	</div>
 	<!-- /wp:group -->

--- a/templates/search.html
+++ b/templates/search.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
 	<!-- wp:query-title {"type":"search"} /-->
-	<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","style":{"border":{"radius":"50px"}},"fontSize":"small"} /-->
+	<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","style":{"border":{"radius":"50px"}},"fontSize":"medium"} /-->
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->
 </main>
 <!-- /wp:group -->

--- a/templates/single.html
+++ b/templates/single.html
@@ -5,10 +5,10 @@
 	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 		<!-- wp:post-terms {"term":"category"} /-->
-		<!-- wp:post-title {"level":1,"fontSize":"x-large"} /-->
+		<!-- wp:post-title {"level":1,"fontSize":"xx-large"} /-->
 		<!-- wp:post-featured-image {"aspectRatio":"3/2"} /-->
 
-		<!-- wp:group {"style":{"spacing":{"blockGap":"5px","margin":{"bottom":"var:preset|spacing|60"}}},"fontSize":"x-small","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"5px","margin":{"bottom":"var:preset|spacing|60"}}},"fontSize":"small","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group has-x-small-font-size" style="margin-bottom:var(--wp--preset--spacing--60)">
 			<!-- wp:paragraph {"textColor":"primary"} -->
 			<p class="has-primary-color has-text-color">Written by </p>

--- a/templates/single.html
+++ b/templates/single.html
@@ -9,7 +9,7 @@
 		<!-- wp:post-featured-image {"aspectRatio":"3/2"} /-->
 
 		<!-- wp:group {"style":{"spacing":{"blockGap":"5px","margin":{"bottom":"var:preset|spacing|60"}}},"fontSize":"small","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group has-x-small-font-size" style="margin-bottom:var(--wp--preset--spacing--60)">
+		<div class="wp-block-group has-small-font-size" style="margin-bottom:var(--wp--preset--spacing--60)">
 			<!-- wp:paragraph {"textColor":"primary"} -->
 			<p class="has-primary-color has-text-color">Written by </p>
 			<!-- /wp:paragraph -->

--- a/theme.json
+++ b/theme.json
@@ -1000,7 +1000,7 @@
 			},
 			"core/post-terms": {
 				"typography": {
-					"fontSize": "var:preset|font-size|x-small",
+					"fontSize": "var:preset|font-size|small",
 					"fontWeight": "600"
 				},
 				"elements": {
@@ -1129,7 +1129,7 @@
 			},
 			"caption": {
 				"typography": {
-					"fontSize": "var:preset|font-size|x-small",
+					"fontSize": "var:preset|font-size|small",
 					"lineHeight": "1.4"
 				}
 			},

--- a/theme.json
+++ b/theme.json
@@ -1063,7 +1063,7 @@
 			},
 			"core/site-title": {
 				"typography": {
-					"fontSize": "var:preset|font-size|medium",
+					"fontSize": "var:preset|font-size|large",
 					"fontWeight": "700",
 					"letterSpacing": "-.5px"
 				},
@@ -1090,7 +1090,7 @@
 			},
 			"core/navigation": {
 				"typography": {
-					"fontSize": "var:preset|font-size|small"
+					"fontSize": "var:preset|font-size|medium"
 				},
 				"elements": {
 					"link": {

--- a/theme.json
+++ b/theme.json
@@ -75,17 +75,17 @@
 					"slug": "50"
 				},
 				{
-					"name": "x-large",
+					"name": "Large",
 					"size": "clamp(30px, 7vw, 70px);",
 					"slug": "60"
 				},
 				{
-					"name": "xx-large",
+					"name": "X-Large",
 					"size": "clamp(50px, 7vw, 90px);",
 					"slug": "70"
 				},
 				{
-					"name": "Xxx-large",
+					"name": "XX-Large",
 					"size": "clamp(70px, 10vw, 140px);",
 					"slug": "80"
 				}

--- a/theme.json
+++ b/theme.json
@@ -924,7 +924,7 @@
 		},
 		"typography": {
 			"fontFamily": "var:preset|font-family|manrope",
-			"fontSize": "var:preset|font-size|medium",
+			"fontSize": "var:preset|font-size|large",
 			"fontStyle": "normal",
 			"fontWeight": "300",
 			"letterSpacing": "-0.22px",

--- a/theme.json
+++ b/theme.json
@@ -75,17 +75,17 @@
 					"slug": "50"
 				},
 				{
-					"name": "Large",
+					"name": "x-large",
 					"size": "clamp(30px, 7vw, 70px);",
 					"slug": "60"
 				},
 				{
-					"name": "X-Large",
+					"name": "xx-large",
 					"size": "clamp(50px, 7vw, 90px);",
 					"slug": "70"
 				},
 				{
-					"name": "XX-Large",
+					"name": "Xxx-large",
 					"size": "clamp(70px, 10vw, 140px);",
 					"slug": "80"
 				}
@@ -105,45 +105,45 @@
 			"fontSizes": [
 				{
 					"fluid": false,
-					"name": "Extra Small",
+					"name": "Small",
 					"size": "0.875rem",
-					"slug": "x-small"
+					"slug": "small"
 				},
 				{
 					"fluid": {
 						"max": "1.125rem",
 						"min": "1rem"
 					},
-					"name": "Small",
+					"name": "Medium",
 					"size": "1rem",
-					"slug": "small"
+					"slug": "medium"
 				},
 				{
 					"fluid": {
 						"max": "1.375rem",
 						"min": "1.125rem"
 					},
-					"name": "Medium",
+					"name": "Large",
 					"size": "1.38rem",
-					"slug": "medium"
+					"slug": "large"
 				},
 				{
 					"fluid": {
 						"max": "2rem",
 						"min": "1.75rem"
 					},
-					"name": "Large",
+					"name": "Extra Large",
 					"size": "1.75rem",
-					"slug": "large"
+					"slug": "x-large"
 				},
 				{
 					"fluid": {
 						"max": "3.625rem",
 						"min": "2.625rem"
 					},
-					"name": "Extra Large",
+					"name": "Extra Extra Large",
 					"size": "2.625rem",
-					"slug": "x-large"
+					"slug": "xx-large"
 				}
 			],
 			"fontFamilies": [
@@ -1032,7 +1032,7 @@
 			},
 			"core/pullquote": {
 				"typography": {
-					"fontSize": "var:preset|font-size|x-large",
+					"fontSize": "var:preset|font-size|xx-large",
 					"fontStyle": "normal",
 					"fontWeight": "300",
 					"letterSpacing": "-0.76px",
@@ -1047,7 +1047,7 @@
 			},
 			"core/query-title":{
 				"typography": {
-					"fontSize": "var:preset|font-size|x-large"
+					"fontSize": "var:preset|font-size|xx-large"
 				}
 			},
 			"core/search": {


### PR DESCRIPTION
**Description**

Followup to #153. Changes slugs and titles to match the T-shirt size indicators in the typography panel.

Before, they were out of sync:

![before](https://github.com/user-attachments/assets/c019d32f-c5ca-4b84-86ea-ca468e9da136)

After, the sizes match:

![after](https://github.com/user-attachments/assets/221c28da-d85e-4713-8471-f30be3664f08)

This is a big one, and could use some careful reviews, mainly because it also updates every existing pattern to swap out the sizes since they all shift one step. My approach was a careful theme-wide search and replace, e.g. replace "x-large" with "xx-large", replace "large" with "x-large", replace "medium" with "large", replace "small" with "medium", replace "x-small" with "small".

I've tested every existing pattern to see that the sizes match, in my testing, they appear to:

![Screenshot 2024-08-30 at 09 17 41](https://github.com/user-attachments/assets/f4ba1b0d-b015-4b2b-be49-5337e883df42)

But would appreciate a sanity check here. 

**Testing Instructions**

Check out the PR, then in a new page, insert patterns fresh and observe that their font sizes match the Figma designs. For any exceptions you see, let me know.

Separately, validate that the font size names/slugs match their T-shirt sizes.