### PR TITLE
Add two new section styles, and 

### DIFF
--- a/patterns/clients-section.php
+++ b/patterns/clients-section.php
@@ -11,8 +11,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"secondary","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-secondary-background-color has-background" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--50)">
+<!-- wp:group {"align":"full","className":"is-style-section-5","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-style-section-5" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--50)">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 		<!-- wp:heading {"textAlign":"center","level":3} -->

--- a/patterns/contact-location-and-link.php
+++ b/patterns/contact-location-and-link.php
@@ -24,7 +24,7 @@
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} -->
-				<p class="has-small-font-size" style="text-transform:uppercase"><a href="#">Get directions</a></p>
+				<p class="has-medium-font-size" style="text-transform:uppercase"><a href="#">Get directions</a></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:group -->

--- a/styles/blocks/section-4.json
+++ b/styles/blocks/section-4.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"slug": "section-4",
+	"title": "Style 4",
+	"blockTypes": [
+		"core/group",
+		"core/columns",
+		"core/column"
+	],
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--contrast)",
+			"text": "var(--wp--preset--color--base)"
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "color-mix(in srgb, currentColor 25%, transparent)"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--base)",
+					"text": "var(--wp--preset--color--contrast)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--base)"
+				}
+			}
+		}
+	}
+}

--- a/styles/blocks/section-5.json
+++ b/styles/blocks/section-5.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"slug": "section-5",
+	"title": "Style 5",
+	"blockTypes": [
+		"core/group",
+		"core/columns",
+		"core/column"
+	],
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--secondary)",
+			"text": "var(--wp--preset--color--contrast)"
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "color-mix(in srgb, currentColor 25%, transparent)"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--contrast)",
+					"text": "var(--wp--preset--color--base)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--contrast)"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
**Description**

Adds two new section styles, fixes a pattern typo, and updates the Clients Section pattern to use section styles.

The two new styles are inspired by these styles in the Figma:

![Screenshot 2024-08-30 at 13 01 34](https://github.com/user-attachments/assets/21b736ab-26af-4030-abc6-562647e2175d)

![Screenshot 2024-08-30 at 13 01 44](https://github.com/user-attachments/assets/2d6d2247-2f8b-4f0c-b943-a20accccf87d)

![Screenshot 2024-08-30 at 13 01 48](https://github.com/user-attachments/assets/83eb580e-75c8-4d48-86ef-3df7d39777b8)

Here's the end results:

![state](https://github.com/user-attachments/assets/b924a197-2e8d-4026-8792-e43d44cf6ea8)

Separately, an issue has surfaced with the Social Icons block:

![icon colors](https://github.com/user-attachments/assets/4f649535-2a8d-4600-9136-093862032e83)

Basically, since we can't globally style the _icon color_, neither can we section-style the icon color. @getdave if you'll forgive the ping. In case you have time to look, do you know how big of a lift it would be in the editor to add global styles support for the Icon Color?

**Testing Instructions**

Try some patterns, including the "Clients section" pattern, with section styles. Test the new beige and black styles.