### PR TITLE
Correct Photo Blog font sizes

### DIFF
--- a/patterns/photo-blog-home-template.php
+++ b/patterns/photo-blog-home-template.php
@@ -17,8 +17,8 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
-	<!-- wp:heading {"textAlign":"center","level":1,"fontSize":"x-small"} -->
-	<h1 class="wp-block-heading has-text-align-center has-x-small-font-size">Stories</h1>
+	<!-- wp:heading {"textAlign":"center","level":1,"fontSize":"small"} -->
+	<h1 class="wp-block-heading has-text-align-center has-small-font-size">Stories</h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:heading {"textAlign":"center","fontSize":"xx-large"} -->

--- a/patterns/photo-blog-single-post-template.php
+++ b/patterns/photo-blog-single-post-template.php
@@ -25,18 +25,18 @@
 			<div class="wp-block-group">
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"constrained"}} -->
 			<div class="wp-block-group">
-				<!-- wp:paragraph {"fontSize":"x-small"} -->
-				<p class="has-x-small-font-size">Published on</p>
+				<!-- wp:paragraph {"fontSize":"small"} -->
+				<p class="has-small-font-size">Published on</p>
 				<!-- /wp:paragraph -->
-				<!-- wp:post-date {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast","fontSize":"x-small"} /-->
+				<!-- wp:post-date {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast","fontSize":"small"} /-->
 			</div>
 			<!-- /wp:group -->
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"constrained"}} -->
 			<div class="wp-block-group">
-				<!-- wp:paragraph {"fontSize":"x-small"} -->
-				<p class="has-x-small-font-size">Posted by</p>
+				<!-- wp:paragraph {"fontSize":"small"} -->
+				<p class="has-small-font-size">Posted by</p>
 				<!-- /wp:paragraph -->
-				<!-- wp:post-author-name {"isLink":true,"fontSize":"x-small"} /-->
+				<!-- wp:post-author-name {"isLink":true,"fontSize":"small"} /-->
 			</div>
 			<!-- /wp:group -->
 			</div>
@@ -45,16 +45,16 @@
 			<div class="wp-block-group">
 				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"constrained"}} -->
 				<div class="wp-block-group">
-					<!-- wp:paragraph {"fontSize":"x-small"} -->
-					<p class="has-x-small-font-size">Categories:</p>
+					<!-- wp:paragraph {"fontSize":"small"} -->
+					<p class="has-small-font-size">Categories:</p>
 					<!-- /wp:paragraph -->
 					<!-- wp:post-terms {"term":"category","style":{"typography":{"fontStyle":"normal","fontWeight":"400"}}} /-->
 				</div>
 				<!-- /wp:group -->
 				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"constrained"}} -->
 				<div class="wp-block-group">
-					<!-- wp:paragraph {"fontSize":"x-small"} -->
-					<p class="has-x-small-font-size">Tagged:</p>
+					<!-- wp:paragraph {"fontSize":"small"} -->
+					<p class="has-small-font-size">Tagged:</p>
 					<!-- /wp:paragraph -->
 					<!-- wp:post-terms {"term":"post_tag","style":{"typography":{"fontStyle":"normal","fontWeight":"400"}}} /-->
 				</div>
@@ -68,8 +68,8 @@
 		<div class="wp-block-group alignwide" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:0;">
 			<!-- wp:group {"tagName":"nav","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 			<nav class="wp-block-group" aria-label="Posts navigation" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
-			<!-- wp:post-navigation-link {"type":"previous","label":"Previous Photo","fontSize":"x-small"} /-->
-			<!-- wp:post-navigation-link {"label":"Next Photo","fontSize":"x-small"} /-->
+			<!-- wp:post-navigation-link {"type":"previous","label":"Previous Photo","fontSize":"small"} /-->
+			<!-- wp:post-navigation-link {"label":"Next Photo","fontSize":"small"} /-->
 			</nav>
 			<!-- /wp:group -->
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
I made a mistake and merged the patterns for the Photo Blog template patterns without updating to the new font sizes.
This PR updates the 'x-small' font sizes.

**Testing Instructions**
Review the code changes, and confirm that text that was previously `x-small` uses the `small` slug for the size.

**Notes**
Photo blog single post: 
I saw that in [Figma](https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=3378-2645&m=dev), the size of the items next to the post title in the header are 18px. In the theme, the items are only 14px.
The author, post date and terms default to 14px in theme.json. So I decided not to update this in this PR.

