### PR TITLE
Pattern: More posts ( Previously "other posts")

### DIFF
--- a/patterns/more-posts.php
+++ b/patterns/more-posts.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Title: More posts
+ * Slug: twentytwentyfive/more-posts
+ * Description: Displays a list of posts with title and date.
+ * Categories: query
+ * Block Types: core/query
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide is-style-default" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+	<!-- wp:heading {"align":"wide","style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"700","letterSpacing":"1.4px"}},"fontSize":"small"} -->
+	<h2 class="wp-block-heading alignwide has-small-font-size" style="font-style:normal;font-weight:700;letter-spacing:1.4px;text-transform:uppercase">More posts</h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:query {"query":{"perPage":4,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]},"align":"wide","layout":{"type":"default"}} -->
+	<div class="wp-block-query alignwide">
+		<!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"default"}} -->
+			<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}},"border":{"bottom":{"color":"var:preset|color|opacity-20","width":"1px"},"top":[],"right":[],"left":[]}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center","justifyContent":"space-between"}} -->
+			<div class="wp-block-group alignfull" style="border-bottom-color:var(--wp--preset--color--opacity-20);border-bottom-width:1px;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+				<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+				<!-- wp:post-date {"textAlign":"right","isLink":true} /-->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:post-template -->
+	</div>
+	<!-- /wp:query -->
+</div>
+<!-- /wp:group -->

--- a/patterns/more-posts.php
+++ b/patterns/more-posts.php
@@ -23,7 +23,7 @@
 		<!-- wp:post-template {"align":"full","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"default"}} -->
 			<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}},"border":{"bottom":{"color":"var:preset|color|opacity-20","width":"1px"},"top":[],"right":[],"left":[]}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center","justifyContent":"space-between"}} -->
 			<div class="wp-block-group alignfull" style="border-bottom-color:var(--wp--preset--color--opacity-20);border-bottom-width:1px;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
-				<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+				<!-- wp:post-title {"level":3,"isLink":true,"fontSize":"large"} /-->
 				<!-- wp:post-date {"textAlign":"right","isLink":true} /-->
 			</div>
 			<!-- /wp:group -->

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -5,6 +5,7 @@
 	<!-- wp:query-title {"type":"archive"} /-->
 	 <!-- wp:term-description /-->
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfive/more-posts"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -5,9 +5,8 @@
 	<!-- wp:heading {"level":1,"fontSize":"xx-large"} -->
 	<h1 class="wp-block-heading has-xx-large-font-size">Blog</h1>
 	<!-- /wp:heading -->
-
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->
-
+	<!-- wp:pattern {"slug":"twentytwentyfive/more-posts"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,9 +5,8 @@
 	<!-- wp:heading {"level":1,"fontSize":"xx-large"} -->
 	<h1 class="wp-block-heading has-xx-large-font-size">Blog</h1>
 	<!-- /wp:heading -->
-
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->
-
+	<!-- wp:pattern {"slug":"twentytwentyfive/more-posts"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/templates/search.html
+++ b/templates/search.html
@@ -5,6 +5,7 @@
 	<!-- wp:query-title {"type":"search"} /-->
 	<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","style":{"border":{"radius":"50px"}},"fontSize":"medium"} /-->
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfive/more-posts"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/templates/single.html
+++ b/templates/single.html
@@ -30,6 +30,9 @@
 
 	</div>
 	<!-- /wp:group -->
+
+	<!-- wp:pattern {"slug":"twentytwentyfive/more-posts"} /-->
+
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Adds a new pattern with a list of posts with the post title and post date, below a heading with the text "More posts",
intended to show above the site footer in several templates.

Closes https://github.com/WordPress/twentytwentyfive/issues/134
[Figma link](https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=3326-1741&m=dev)


**Testing Instructions**

Apply the PR and view the updated templates. Confirm that the pattern matches the design.
- Home
- Index
- Archive
- Search
- Single post

To test the index, first rename or delete the home template, then the index template file will be used as the front page on the front of the site.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

