### PR TITLE
Fix: "Contact centered and social" pattern width.

### DIFF
--- a/patterns/contact-centered-social-link.php
+++ b/patterns/contact-centered-social-link.php
@@ -11,19 +11,23 @@
  */
 
 ?>
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"},"blockGap":"var:preset|spacing|50"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)">
-	<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-size--huge)"}}} -->
-	<p class="has-text-align-center" style="font-size:var(--wp--custom--font-size--huge);"><?php echo wp_kses_post( _x( 'Got questions? <br><a href="#" rel="nofollow">Feel free to reach out.</a>', 'Heading of the Contact social link pattern', 'twentytwentyfive' ) ); ?></p>
-	<!-- /wp:paragraph -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"},"blockGap":"var:preset|spacing|50","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)">
+	<!-- wp:group {"align":"wide","layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
+	<div class="wp-block-group alignwide">
+		<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"var(--wp--custom--font-size--huge)"}}} -->
+		<p class="has-text-align-center" style="font-size:var(--wp--custom--font-size--huge);"><?php echo wp_kses_post( _x( 'Got questions? <br><a href="#" rel="nofollow">Feel free to reach out.</a>', 'Heading of the Contact social link pattern', 'twentytwentyfive' ) ); ?></p>
+		<!-- /wp:paragraph -->
 
-	<!-- wp:social-links {"iconColor":"contrast","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"center"}} -->
-	<ul class="wp-block-social-links has-icon-color is-style-logos-only">
-		<!-- wp:social-link {"url":"#","service":"twitter"} /-->
-		<!-- wp:social-link {"url":"#","service":"facebook"} /-->
-		<!-- wp:social-link {"url":"#","service":"instagram"} /-->
-		<!-- wp:social-link {"url":"#","service":"pinterest"} /-->
-	</ul>
-	<!-- /wp:social-links -->
+		<!-- wp:social-links {"iconColor":"contrast","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"center"}} -->
+		<ul class="wp-block-social-links has-icon-color is-style-logos-only">
+			<!-- wp:social-link {"url":"#","service":"twitter"} /-->
+			<!-- wp:social-link {"url":"#","service":"facebook"} /-->
+			<!-- wp:social-link {"url":"#","service":"instagram"} /-->
+			<!-- wp:social-link {"url":"#","service":"pinterest"} /-->
+		</ul>
+		<!-- /wp:social-links -->
+	</div>
+	<!-- /wp:group -->
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION


<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Add full width to parent group and add wrapper to put the content in wide width.

Follow-up of https://github.com/WordPress/twentytwentyfive/pull/173#pullrequestreview-2275041636

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

https://github.com/user-attachments/assets/8a895961-768a-48fb-95c5-08df4e65888e

**Testing Instructions**

1. Create a page.
2. Add the pattern, add a background color to the parent group.
3. View the page in a big screen, confirm that the background is taking the full width and that the content is limited to wide width.
