### PR TITLE
Accessibility: Quick fixes of pattern: service-three-columns and hero-centered-heading

### DIFF
--- a/patterns/hero-centered-heading.php
+++ b/patterns/hero-centered-heading.php
@@ -15,8 +15,8 @@
 <div class="wp-block-group alignfull" style="min-height:0vh;margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--40);">
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
-		<!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"right":"0","left":"0"},"padding":{"right":"0","left":"0"}}}} -->
-		<h1 class="wp-block-heading has-text-align-center" style="margin-right:0;margin-left:0;padding-right:0;padding-left:0">Tell your story</h1>
+		<!-- wp:heading {"fontSize": "xx-large", "textAlign":"center","level":2,"style":{"spacing":{"margin":{"right":"0","left":"0"},"padding":{"right":"0","left":"0"}}}} -->
+		<h2 class="wp-block-heading has-text-align-center has-xx-large-font-size" style="margin-right:0;margin-left:0;padding-right:0;padding-left:0;">Tell your story</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center"} -->

--- a/patterns/services-three-columns.php
+++ b/patterns/services-three-columns.php
@@ -27,7 +27,7 @@
 			</figure>
 			<!-- /wp:image -->
 
-			<!-- wp:heading {"level":4} -->
+			<!-- wp:heading {"level":3} -->
 			<h4 class="wp-block-heading">Collect</h4>
 			<!-- /wp:heading -->
 
@@ -45,7 +45,7 @@
 			</figure>
 			<!-- /wp:image -->
 
-			<!-- wp:heading {"level":4} -->
+			<!-- wp:heading {"level":3} -->
 			<h4 class="wp-block-heading">Assemble</h4>
 			<!-- /wp:heading -->
 
@@ -63,7 +63,7 @@
 			</figure>
 			<!-- /wp:image -->
 
-			<!-- wp:heading {"level":4} -->
+			<!-- wp:heading {"level":3} -->
 			<h4 class="wp-block-heading">Deliver</h4>
 			<!-- /wp:heading -->
 


### PR DESCRIPTION
**Description**

Quick fixes of headline structure of the pattern: service-three-columns and hero-centered-heading

Logical order of service-three-columns should be

```
h2
   h3
   h3
   h3
```

not 

```
h2
   h4
   h4
   h4
```

---

In the hero-center-heading we probably shouldn't use H1 as the headline. Because this pattern can be pasted in every post or page. On single pages and posts, the post title should be the only H1.

