### PR TITLE
Fix block validation error in the "right aligned" page template

### DIFF
--- a/patterns/vertical-header-right-aligned-page-template.php
+++ b/patterns/vertical-header-right-aligned-page-template.php
@@ -52,7 +52,7 @@
 				</div>
 				<!-- /wp:column -->
 				<!-- wp:column {"width":"25%"} -->
-				<div class="wp-block-column" style="flex-basis:25%">¨
+				<div class="wp-block-column" style="flex-basis:25%">
 				<!-- wp:template-part {"slug":"right-aligned-sidebar"} /-->
 				</div>
 				<!-- /wp:column -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
There is an incorrect stray character in the page template for the vertical header/ right aligned design.
The character causes a block validation, and this PR removes the character.

**Testing Instructions**

Open the Site Editor.
Confirm that there is no JavaScript error for a block validation error in the browser console.