### PR TITLE
Create pill style variation

### DIFF
--- a/styles/blocks/pill.json
+++ b/styles/blocks/pill.json
@@ -18,7 +18,7 @@
 		},
 		"spacing": {
 			"padding": {
-				"top": "5px",
+				"top": "0.31rem",
 				"right": "var:preset|spacing|20",
 				"bottom": "0.31rem",
 				"left": "var:preset|spacing|20"

--- a/styles/blocks/pill.json
+++ b/styles/blocks/pill.json
@@ -5,11 +5,11 @@
 	"slug": "pill",
 	"blockTypes": ["core/heading", "core/paragraph"],
 	"styles": {
-        "typography": {
-            "fontSize": "var:preset|font-size|small",
-            "lineHeight": "1",
-            "letterSpacing": "normal"
-        },
+		"typography": {
+			"fontSize": "var:preset|font-size|small",
+			"lineHeight": "1",
+			"letterSpacing": "normal"
+		},
 		"border": {
 			"color": "var:preset|color|contrast",
 			"style": "solid",

--- a/styles/blocks/pill.json
+++ b/styles/blocks/pill.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"title": "Pill",
+	"slug": "pill",
+	"blockTypes": ["core/heading", "core/paragraph"],
+	"styles": {
+		"border": {
+			"color": "var:preset|color|contrast",
+			"style": "solid",
+			"width": "1px",
+			"radius": "20px"
+		},
+		"spacing": {
+			"padding": {
+				"top": "5px",
+				"right": "var:preset|spacing|tiny",
+				"bottom": "5px",
+				"left": "var:preset|spacing|tiny"
+			}
+		}
+	}
+}

--- a/styles/blocks/pill.json
+++ b/styles/blocks/pill.json
@@ -20,7 +20,7 @@
 			"padding": {
 				"top": "5px",
 				"right": "var:preset|spacing|20",
-				"bottom": "5px",
+				"bottom": "0.31rem",
 				"left": "var:preset|spacing|20"
 			}
 		}

--- a/styles/blocks/pill.json
+++ b/styles/blocks/pill.json
@@ -5,6 +5,11 @@
 	"slug": "pill",
 	"blockTypes": ["core/heading", "core/paragraph"],
 	"styles": {
+        "typography": {
+            "fontSize": "var:preset|font-size|small",
+            "lineHeight": "1",
+            "letterSpacing": "normal"
+        },
 		"border": {
 			"color": "var:preset|color|contrast",
 			"style": "solid",
@@ -14,9 +19,9 @@
 		"spacing": {
 			"padding": {
 				"top": "5px",
-				"right": "var:preset|spacing|tiny",
+				"right": "var:preset|spacing|20",
 				"bottom": "5px",
-				"left": "var:preset|spacing|tiny"
+				"left": "var:preset|spacing|20"
 			}
 		}
 	}

--- a/styles/blocks/pill.json
+++ b/styles/blocks/pill.json
@@ -14,7 +14,7 @@
 			"color": "var:preset|color|contrast",
 			"style": "solid",
 			"width": "1px",
-			"radius": "20px"
+			"radius": "999px"
 		},
 		"spacing": {
 			"padding": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This adds a style variation for paragraphs and headings.  **It does not apply the style to any patterns or templates.**
Partial for https://github.com/WordPress/twentytwentyfive/issues/195

**Screenshots**
![image](https://github.com/user-attachments/assets/b73f980b-804c-4a09-90a4-2c6d73fc8a3b)



**Testing Instructions**
Add a heading block and apply the "pill" style from the block settings sidebar.
Add a paragraph and apply the "pill" style from the block settings sidebar.
Confirm if the style [matches the design in Figma](https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=3177-1485&m=dev)
