### PR TITLE
Fix pull-quote block top & bottom white spacing issue.

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1174,7 +1174,14 @@
 					"fontWeight": "300",
 					"letterSpacing": "-0.76px",
 					"lineHeight": "1.2"
+				},
+				"spacing": {
+					"padding": {
+						"top": "20px",
+						"bottom": "20px"
+					}
 				}
+
 			},
 			"core/query-pagination": {
 				"typography": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Here, I have resolved pull-quote block white spacing issue and created my PR.

**Screenshots**

![after-resolve-twenty-twenty-five-pull-quote-editor-side](https://github.com/user-attachments/assets/aa566579-fa9a-496c-bdc6-b95dc993a703)
![after-resolved-twenty-twenty-five-pull-quote-front-end](https://github.com/user-attachments/assets/74e8af3e-2464-411f-959c-e302d1197322)


**Testing Instructions**
Please follow below-mentioned steps to test this.

- Go to admin and select the "Pull-quote" block first.
- Add its paragraph text & citation text.
- Set it border to see it more clear.
- Update the page and check its admin text and front-end text.
