### PR TITLE
Update heading sizes and default home template

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -2,8 +2,8 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
-<!-- wp:heading {"textAlign":"left","level":1,"className":"is-style-default"} -->
-<h1 class="wp-block-heading has-text-align-left is-style-default">Blog</h1>
+<!-- wp:heading {"textAlign":"left","level":1"} -->
+<h1 class="wp-block-heading has-text-align-left">Blog</h1>
 <!-- /wp:heading -->
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->
 	<!-- wp:pattern {"slug":"twentytwentyfive/more-posts"} /-->

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,9 +2,9 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
-	<!-- wp:heading {"level":1,"fontSize":"xx-large"} -->
-	<h1 class="wp-block-heading has-xx-large-font-size">Blog</h1>
-	<!-- /wp:heading -->
+<!-- wp:heading {"textAlign":"left","level":1,"className":"is-style-default"} -->
+<h1 class="wp-block-heading has-text-align-left is-style-default">Blog</h1>
+<!-- /wp:heading -->
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->
 	<!-- wp:pattern {"slug":"twentytwentyfive/more-posts"} /-->
 </main>

--- a/theme.json
+++ b/theme.json
@@ -1307,34 +1307,36 @@
 			},
 			"h1": {
 				"typography": {
-					"fontSize":"var(--wp--custom--font-size--huge)"
+					"fontSize": "2.62rem"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontSize": "48px"
+					"fontSize": "1.8rem"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontSize": "38px"
+					"fontSize": "1.64rem"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontSize": "28px"
+					"fontSize": "1.5rem"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontSize": "24px"
+					"fontSize": "1.25rem"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontSize": "var:preset|font-size|medium",
+					"fontSize": "0.875rem",
 					"fontStyle": "normal",
-					"fontWeight": "700"
+					"fontWeight": "700",
+					"letterSpacing": "1.4px",
+					"textTransform": "uppercase"
 				}
 			},
 			"heading": {


### PR DESCRIPTION
**Description**

Currently, the default home template looks like this if we add a post with some headings in the content:

![Captura de ecrã 2024-09-05, às 16 24 05](https://github.com/user-attachments/assets/9e6e6384-8452-44ea-8abc-00cd5497c579)

It's not a good look that the post title is smaller than the subsequent headings from the post content.

So I tinkered with the heading sizes in global styles to see how we could solve this issue. I also checked with the patterns and although the scale of the headings in some of them is a bit smaller, I think they still look good. This is how it looks with the updated suggestion:

![Captura de ecrã 2024-09-05, às 16 28 20](https://github.com/user-attachments/assets/f6d9a452-f6f2-4902-92e7-66bb8a94cc6e)

The sizes are the following:

**H1: 2.62rem
H2: 1.8rem
H3: 1.64rem
H4: 1.5rem
H5: 1.25rem
H6: 0.875rem (Bold, uppercase, 1.4px letter spacing)**

I also changed the font size of the "Blog" heading in the actual template.

Once these are reviewed, I'll update these heading sizes on the Figma file for coherency.