### PR TITLE
Home template: Fix block validation error

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -2,7 +2,7 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
-<!-- wp:heading {"textAlign":"left","level":1"} -->
+<!-- wp:heading {"textAlign":"left","level":1} -->
 <h1 class="wp-block-heading has-text-align-left">Blog</h1>
 <!-- /wp:heading -->
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
When I merged the update to the font sizes and the home template,  I removed the unused class name `is-style-default` and accidently left a breaking `"` in the markup. This PR removes that double quote.

