### PR TITLE
Fix theme json missing templatepart issue.

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1361,6 +1361,16 @@
 			"area": "footer",
 			"name": "footer",
 			"title": "Footer"
-		}
+		},
+		{
+            "area": "sidebar",
+            "name": "right-aligned-sidebar",
+            "title": "Right Aligned Sidebar"
+        },
+		{
+            "area": "sidebar",
+            "name": "sidebar",
+            "title": "Sidebar"
+        }
 	]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Here, I have added missing templateParts from the parts folder to theme.json

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**

<!-- Provide steps for testing -->
<!-- 1. Activate the theme. -->
<!-- 2. Visit the archives page. -->
<!-- 3. etc. -->
