### PR TITLE
Add default style for the separator block

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,11 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
+This theme incorporates code from:
+
+Twenty Twenty-Four WordPress Theme, (C) 2023 WordPress.org
+License: GPLv2 or later. License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
 
 This theme bundles the following third-party resources:
 

--- a/theme.json
+++ b/theme.json
@@ -1248,6 +1248,16 @@
 					}
 				}
 			},
+			"core/separator": {
+				"border": {
+					"color": "currentColor",
+					"style": "solid",
+					"width": "0 0 1px 0"
+				},
+				"color": {
+					"text": "var:preset|color|opacity-20"
+				}
+			},
 			"core/site-tagline": {
 				"typography": {
 					"fontSize": "var:preset|font-size|small"


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This PR adds a default style for the separator block, using a 1px border with the color opacity-20.
I copied this solution from Twenty Twenty-Four, so I added the credits to the readme.txt file.

Closes https://github.com/WordPress/twentytwentyfive/issues/241

**Screenshots**
![image](https://github.com/user-attachments/assets/6796832f-575a-438a-be44-4f1897c5d6bb)

**Testing Instructions**
Apply the PR and insert the separator block.
Try the different widths and styles of the block.
