### PR TITLE
Changed Pattern Title & Description

### DIFF
--- a/patterns/intro-short-heading-image.php
+++ b/patterns/intro-short-heading-image.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Title: Short heading and paragraph and image on the right
+ * Title: Short heading and paragraph and image on the left
  * Slug: twentytwentyfive/intro-short-heading-image
  * Categories: banner
- * Description: A Intro pattern with Short heading, paragraph and image on the right.
+ * Description: A Intro pattern with Short heading, paragraph and image on the left.
  *
  * @package WordPress
  * @subpackage Twenty_Twenty_Five


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

<!-- Describe the purpose or reason for the pull request -->
In **`Hero - Short heading and paragraph and image on the right`** Pattern, the image is visually displayed on the left side. Therefore, the title and description should be updated to reflect the image being on the left instead of the right.

### **Screenshots:**
![short-heading-with-image](https://github.com/user-attachments/assets/99599771-94af-4d08-885c-9588b318faa7)

### **Testing Instructions:**

1. Activate TT5 Theme
2. Create Page & Insert the `Short heading and paragraph and image on the right` Pattern.
3. Now Open patterns/intro-short-heading-image.php file & View Title & Description
