### PR TITLE
Refactor: Replace `var(--wp--preset--feature-slug)` with `var:preset|…

### DIFF
--- a/styles/blocks/section-1.json
+++ b/styles/blocks/section-1.json
@@ -10,8 +10,8 @@
 	],
 	"styles": {
 		"color": {
-			"background": "var(--wp--preset--color--accent-2)",
-			"text": "var(--wp--preset--color--contrast)"
+			"background": "var:preset|color|accent-2",
+			"text": "var:preset|color|contrast"
 		},
 		"blocks": {
 			"core/separator": {
@@ -23,13 +23,13 @@
 		"elements": {
 			"button": {
 				"color": {
-					"background": "var(--wp--preset--color--contrast)",
-					"text": "var(--wp--preset--color--base)"
+					"background": "var:preset|color|contrast",
+					"text": "var:preset|color|base"
 				}
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--preset--color--contrast)"
+					"text": "var:preset|color|contrast"
 				}
 			}
 		}

--- a/styles/blocks/section-2.json
+++ b/styles/blocks/section-2.json
@@ -10,8 +10,8 @@
 	],
 	"styles": {
 		"color": {
-			"background": "var(--wp--preset--color--accent-3)",
-			"text": "var(--wp--preset--color--accent-2)"
+			"background": "var:preset|color|accent-3",
+			"text": "var:preset|color|accent-2"
 		},
 		"blocks": {
 			"core/separator": {
@@ -23,13 +23,13 @@
 		"elements": {
 			"button": {
 				"color": {
-					"background": "var(--wp--preset--color--contrast)",
-					"text": "var(--wp--preset--color--base)"
+					"background": "var:preset|color|contrast",
+					"text": "var:preset|color|base"
 				}
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--preset--color--accent-2)"
+					"text": "var:preset|color|accent-2"
 				}
 			}
 		}

--- a/styles/blocks/section-3.json
+++ b/styles/blocks/section-3.json
@@ -10,8 +10,8 @@
 	],
 	"styles": {
 		"color": {
-			"background": "var(--wp--preset--color--accent-1)",
-			"text": "var(--wp--preset--color--contrast)"
+			"background": "var:preset|color|accent-1",
+			"text": "var:preset|color|contrast"
 		},
 		"blocks": {
 			"core/separator": {
@@ -23,13 +23,13 @@
 		"elements": {
 			"button": {
 				"color": {
-					"background": "var(--wp--preset--color--contrast)",
-					"text": "var(--wp--preset--color--base)"
+					"background": "var:preset|color|contrast",
+					"text": "var:preset|color|base"
 				}
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--preset--color--contrast)"
+					"text": "var:preset|color|contrast"
 				}
 			}
 		}

--- a/styles/blocks/section-4.json
+++ b/styles/blocks/section-4.json
@@ -10,8 +10,8 @@
 	],
 	"styles": {
 		"color": {
-			"background": "var(--wp--preset--color--contrast)",
-			"text": "var(--wp--preset--color--base)"
+			"background": "var:preset|color|contrast",
+			"text": "var:preset|color|base"
 		},
 		"blocks": {
 			"core/separator": {
@@ -23,13 +23,13 @@
 		"elements": {
 			"button": {
 				"color": {
-					"background": "var(--wp--preset--color--base)",
-					"text": "var(--wp--preset--color--contrast)"
+					"background": "var:preset|color|base",
+					"text": "var:preset|color|contrast"
 				}
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--preset--color--base)"
+					"text": "var:preset|color|base"
 				}
 			}
 		}

--- a/styles/blocks/section-5.json
+++ b/styles/blocks/section-5.json
@@ -10,8 +10,8 @@
 	],
 	"styles": {
 		"color": {
-			"background": "var(--wp--preset--color--secondary)",
-			"text": "var(--wp--preset--color--contrast)"
+			"background": "var:preset|color|secondary",
+			"text": "var:preset|color|contrast"
 		},
 		"blocks": {
 			"core/separator": {
@@ -23,13 +23,13 @@
 		"elements": {
 			"button": {
 				"color": {
-					"background": "var(--wp--preset--color--contrast)",
-					"text": "var(--wp--preset--color--base)"
+					"background": "var:preset|color|contrast",
+					"text": "var:preset|color|base"
 				}
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--preset--color--contrast)"
+					"text": "var:preset|color|contrast"
 				}
 			}
 		}

--- a/theme.json
+++ b/theme.json
@@ -923,8 +923,8 @@
 		"spacing": {
 			"blockGap": "1.2rem",
 			"padding": {
-				"left": "var(--wp--preset--spacing--50)",
-				"right": "var(--wp--preset--spacing--50)"
+				"left": "var:preset|spacing|50",
+				"right": "var:preset|spacing|50"
 			}
 		},
 		"typography": {


### PR DESCRIPTION
…$feature|$slug` syntax

Updated all instances where `var(--wp--preset--feature-slug)` was used to the recommended `var:preset|$feature|$slug` syntax for consistency and improved maintainability.

Solving the issue #29 
