### PR TITLE
Remove the class name is-style-default#249

### DIFF
--- a/patterns/banner-with-description-and-images-grid.php
+++ b/patterns/banner-with-description-and-images-grid.php
@@ -11,8 +11,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","className":"is-style-default","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-default">
+<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"blockGap":"var:preset|spacing|60"}},"layout":{"type":"grid","minimumColumnWidth":"32rem"}} -->
 	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 		<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between","justifyContent":"stretch"}} -->

--- a/patterns/contact-location-and-link.php
+++ b/patterns/contact-location-and-link.php
@@ -33,8 +33,8 @@
 
 		<!-- wp:column {"verticalAlignment":"top","width":"40%"} -->
 		<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:40%">
-			<!-- wp:image {"aspectRatio":"1","scale":"cover","linkDestination":"none","className":"wp-block-image size-large is-style-default"} -->
-			<figure class="wp-block-image size-large is-style-default"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/location.webp" alt="The business location" /></figure>
+			<!-- wp:image {"aspectRatio":"1","scale":"cover","linkDestination":"none","className":"wp-block-image size-large"} -->
+			<figure class="wp-block-image size-large"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/location.webp" alt="The business location" /></figure>
 			<!-- /wp:image --></div>
 		<!-- /wp:column -->
 		</div>

--- a/patterns/more-posts.php
+++ b/patterns/more-posts.php
@@ -13,7 +13,7 @@
 
 ?>
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide is-style-default" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 	<!-- wp:heading {"align":"wide","style":{"typography":{"textTransform":"uppercase","fontStyle":"normal","fontWeight":"700","letterSpacing":"1.4px"}},"fontSize":"small"} -->
 	<h2 class="wp-block-heading alignwide has-small-font-size" style="font-style:normal;font-weight:700;letter-spacing:1.4px;text-transform:uppercase">More posts</h2>
 	<!-- /wp:heading -->

--- a/patterns/services-three-columns.php
+++ b/patterns/services-three-columns.php
@@ -39,8 +39,8 @@
 
 		<!-- wp:column -->
 		<div class="wp-block-column">
-			<!-- wp:image {"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","className":"is-style-default"} -->
-			<figure class="wp-block-image size-full is-style-default">
+			<!-- wp:image {"aspectRatio":"4/3","scale":"cover","sizeSlug":"full"} -->
+			<figure class="wp-block-image size-full">
 				<img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/image-from-rawpixel-id-2224378.webp" alt="Image for service" style="aspect-ratio:4/3;object-fit:cover"/>
 			</figure>
 			<!-- /wp:image -->

--- a/patterns/text-only-blog-single-post-template.php
+++ b/patterns/text-only-blog-single-post-template.php
@@ -18,7 +18,7 @@
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
 	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
-		<!-- wp:post-terms {"term":"category","className":"is-style-default","style":{"typography":{"fontStyle":"normal","fontWeight":"400"}}} /-->
+		<!-- wp:post-terms {"term":"category","style":{"typography":{"fontStyle":"normal","fontWeight":"400"}}} /-->
 		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"fontSize":"xx-large"} /-->
 
 		<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This issue resolved: Remove the class name "is-style-default" #249
"is-style-default" is added by the block editor if a user selects a block style variation and then switches back to the default style. I have removed this from all patterns where it was used.
<!-- Describe the purpose or reason for the pull request -->


<!-- Provide steps for testing -->
<!-- 1. Activate the theme. -->
<!-- 2. Visit the archives page. -->
<!-- 3. etc. -->
