### PR TITLE
Fix a reference to a non-existent file name

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -27,11 +27,11 @@ endif;
 add_action( 'after_setup_theme', 'twentytwentyfive_editor_style' );
 
 /**
- * Enqueue stylesheet.css on the front.
+ * Enqueue style.css on the front.
  */
 if ( ! function_exists( 'twentytwentyfive_enqueue_styles' ) ) :
 	/**
-	 * Enqueue stylesheet.css on the front.
+	 * Enqueue style.css on the front.
 	 *
 	 * @since Twenty Twenty-Five 1.0
 	 * @return void


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

<!-- Describe the purpose or reason for the pull request -->

Fix mentions of a non-existent `stylesheet.css` file, supposedly meant to be `style.css`.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**

<!-- Provide steps for testing -->
<!-- 1. Activate the theme. -->
<!-- 2. Visit the archives page. -->
<!-- 3. etc. -->
