### PR TITLE
Added Default Separator Width

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1256,7 +1256,8 @@
 				},
 				"color": {
 					"text": "var:preset|color|opacity-20"
-				}
+				},
+				"css": " &:not(.is-style-wide):not(.is-style-dots):not(.alignwide):not(.alignfull){width: var(--wp--preset--spacing--60)}"
 			},
 			"core/site-tagline": {
 				"typography": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

### **Description:**

The Width of the `Default Separator` and the `Wide Separator` Width are currently Identical. I have included the default separator width adjustment in this pull request.

### **Screenshots:**

**Before PR:**

![before-default-separator](https://github.com/user-attachments/assets/cbd47f09-6658-4f96-b8c5-fc48210dba17)

**After PR:**

![after-default-separator](https://github.com/user-attachments/assets/5b8a108a-b8ac-4e15-acaa-aa076d99a4dd)


### **Testing Instructions:**

1. Activate the TT5 theme. 
2. Create a page or select existing page.
3. Select Separator Block.
