### PR TITLE
Add custom font sizes for headings.

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -926,7 +926,13 @@
 		},
 		"custom": {
 			"fontSize": {
-				"huge": "clamp(2.5rem, 4vw, 4.375rem)"
+				"huge": "clamp(2.5rem, 4vw, 4.375rem)",
+				"heading-1": "clamp(1.561rem, 1.2288rem + 1.661vw, 2.62rem)",
+				"heading-2": "clamp(1.146rem, 0.9408rem + 1.026vw, 1.8rem)",
+				"heading-3": "clamp(1.06rem, 0.878rem + 0.91vw, 1.64rem)",
+				"heading-4": "clamp(0.984rem, 0.8222rem + 0.809vw, 1.5rem)",
+				"heading-5": "clamp(0.875rem, 0.7574rem + 0.588vw, 1.25rem)",
+				"heading-6": "0.875rem"
 			}
 		},
 		"useRootPaddingAwareAlignments": true


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Fixes https://github.com/WordPress/twentytwentyfive/issues/170

I'm adding custom font sizes for headings so that we can use the different heading sizes in other elements to respect the sizes in the design without neglecting accessibility concerns. 

The variables will be:
```
--wp--custom--font-size--heading-1
--wp--custom--font-size--heading-2
--wp--custom--font-size--heading-3
--wp--custom--font-size--heading-4
--wp--custom--font-size--heading-5
--wp--custom--font-size--heading-6
```

Tried to go with just `h1`, ..., `h6` as the values in the `theme.json` but then they were formatted as `--wp--custom--font-size--h-2` and I thought that having `heading` could result in a better devex. I'm happy to switch back to the other option if that's considered a better idea.

For the values, I went with the computed values using `clamp()`.


**Screenshots**

- N/A

**Testing Instructions**

- Open a page
- Check the CSS variables
- Confirm that you see the new variables with their values.
