### PR TITLE
Use custom font size headings for definitions

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1381,32 +1381,32 @@
 			},
 			"h1": {
 				"typography": {
-					"fontSize": "2.62rem"
+					"fontSize": "var:custom|font-size|heading-1"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontSize": "1.8rem"
+					"fontSize": "var:custom|font-size|heading-2"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontSize": "1.64rem"
+					"fontSize": "var:custom|font-size|heading-3"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontSize": "1.5rem"
+					"fontSize": "var:custom|font-size|heading-4"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontSize": "1.25rem"
+					"fontSize": "var:custom|font-size|heading-5"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontSize": "0.875rem",
+					"fontSize": "var:custom|font-size|heading-6",
 					"fontStyle": "normal",
 					"fontWeight": "700",
 					"letterSpacing": "1.4px",

--- a/theme.json
+++ b/theme.json
@@ -1306,7 +1306,7 @@
 			},
 			"core/term-description": {
 				"color":{
-					"text":"var:preset|color|primary"
+					"text": "var:preset|color|primary"
 				},
 				"typography": {
 					"fontSize": "var:preset|font-size|small"

--- a/theme.json
+++ b/theme.json
@@ -1439,14 +1439,14 @@
 			"title": "Footer"
 		},
 		{
-            "area": "uncategorized",
-            "name": "right-aligned-sidebar",
-            "title": "Right Aligned Sidebar"
-        },
+			"area": "uncategorized",
+			"name": "right-aligned-sidebar",
+			"title": "Right Aligned Sidebar"
+		},
 		{
-            "area": "uncategorized",
-            "name": "sidebar",
-            "title": "Sidebar"
-        }
+			"area": "uncategorized",
+			"name": "sidebar",
+			"title": "Sidebar"
+		}
 	]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Partial for https://github.com/WordPress/twentytwentyfive/issues/170

Follow up of https://github.com/WordPress/twentytwentyfive/pull/269 - I didn't push the commit in the branch before it was merged.

The idea of this code is to use the new custom sizes for headings in the headings definition.

**Screenshots**

- N/A

**Testing Instructions**

1. Create a page.
2. Add all headings (h1, h2, h3, h4, h5, h6)
3. Confirm that the sizes are as expected.
