### PR TITLE
Visual adjustments to default blog templates

### DIFF
--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -27,8 +27,8 @@
 		<div class="wp-block-column is-vertically-aligned-bottom">
 			<!-- wp:group {"layout":{"type":"default"}} -->
 			<div class="wp-block-group">
-				<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"48px"}}} -->
-				<h1 class="wp-block-heading" style="font-size:48px">
+				<!-- wp:heading {"level":1} -->
+				<h1 class="wp-block-heading">
 					<?php echo esc_html_x( 'Page not found', '404 error message', 'twentytwentyfive' ); ?>
 				</h1>
 				<!-- /wp:heading -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,8 +2,8 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
-	<!-- wp:heading {"level":1,"fontSize":"xx-large"} -->
-	<h1 class="wp-block-heading has-xx-large-font-size">Blog</h1>
+	<!-- wp:heading {"level":1} -->
+	<h1 class="wp-block-heading">Blog</h1>
 	<!-- /wp:heading -->
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->
 	<!-- wp:pattern {"slug":"twentytwentyfive/more-posts"} /-->

--- a/templates/page.html
+++ b/templates/page.html
@@ -5,7 +5,7 @@
 	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 		<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} /-->
-		<!-- wp:post-title {"level":1,"fontSize":"xx-large"} /-->
+		<!-- wp:post-title {"level":1} /-->
 		<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
 	</div>
 	<!-- /wp:group -->

--- a/templates/single.html
+++ b/templates/single.html
@@ -5,7 +5,7 @@
 	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 		<!-- wp:post-terms {"term":"category"} /-->
-		<!-- wp:post-title {"level":1,"fontSize":"xx-large"} /-->
+		<!-- wp:post-title {"level":1} /-->
 		<!-- wp:post-featured-image {"aspectRatio":"3/2"} /-->
 
 		<!-- wp:group {"style":{"spacing":{"blockGap":"5px","margin":{"bottom":"var:preset|spacing|60"}}},"fontSize":"small","layout":{"type":"flex","flexWrap":"nowrap"}} -->

--- a/theme.json
+++ b/theme.json
@@ -1246,11 +1246,6 @@
 					"fontWeight": "500"
 				}
 			},
-			"core/query-title":{
-				"typography": {
-					"fontSize": "var:preset|font-size|xx-large"
-				}
-			},
 			"core/search": {
 				"css": "& .wp-block-search__input{border-radius:3.125rem;padding-left:1.5625rem;padding-right:1.5625rem;}",
 				"typography": {


### PR DESCRIPTION
**Description**

Currently, the default blog templates have local customisations to the headings font sizes, and blocks like Query Title in archive, search results have specific font size presets set globally as well. With the recent heading sizes adjustments in #231, these local customisations are no longer necessary and actually make the templates look worse. So I went ahead and made the following changes:

- Removed local font size preset from the **Title** in the `single.html`
- Removed local font size preset from the **Title** in the `page.html`
- Removed local font size preset from **Query Title** in `theme.json`
- Removed local font size preset set to **H1** in `index.html`
- Removed local font size preset from **H1** in `hidden-404.php`

**Screenshots**

Here's what I mean, notice how it's much more comfortable to read the post title. And it's also more approximate to the Figma's original intention.

| Before | After |
| ---- | ---- |
| ![Captura de ecrã 2024-09-11, às 15 28 51](https://github.com/user-attachments/assets/a2eeb64f-2df3-4271-bdbf-40a72033665b) | ![Captura de ecrã 2024-09-11, às 15 28 39](https://github.com/user-attachments/assets/fbb78f2a-ae83-4ff7-81d6-8d3d4e613285) |