### PR TITLE
Added missing <main> to template partterns starting with name vertical-header-right

### DIFF
--- a/patterns/vertical-header-right-aligned-archive-template.php
+++ b/patterns/vertical-header-right-aligned-archive-template.php
@@ -35,20 +35,24 @@
 
 	<!-- wp:column {"width":"90%","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50);flex-basis:90%">
-		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-		<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
-		<!-- wp:query-title {"type":"archive","fontSize":"large"} /-->
-		<!-- wp:term-description /-->
-		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-		<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
+		<!-- wp:group {"tagName":"main","layout":{"type":"default"}} -->
+		<main class="wp-block-group">
+			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+			<!-- wp:query-title {"type":"archive","fontSize":"large"} /-->
+			<!-- wp:term-description /-->
+			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
 
-		<!-- wp:pattern {"slug":"twentytwentyfive/right-aligned-posts"} /-->
+			<!-- wp:pattern {"slug":"twentytwentyfive/right-aligned-posts"} /-->
 
-		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-		<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
+			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+		</main>
+		<!-- /wp:group -->
 	</div>
 	<!-- /wp:column -->
 </div>

--- a/patterns/vertical-header-right-aligned-home-template.php
+++ b/patterns/vertical-header-right-aligned-home-template.php
@@ -35,15 +35,19 @@
 
 	<!-- wp:column {"width":"90%","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}}} -->
 	<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50);flex-basis:90%">
-		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-		<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
+		<!-- wp:group {"tagName":"main","layout":{"type":"default"}} -->
+		<main class="wp-block-group">
+			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
 
-		<!-- wp:pattern {"slug":"twentytwentyfive/right-aligned-posts"} /-->
+			<!-- wp:pattern {"slug":"twentytwentyfive/right-aligned-posts"} /-->
 
-		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-		<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
+			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+		</main>
+		<!-- /wp:group -->
 	</div>
 	<!-- /wp:column -->
 </div>

--- a/patterns/vertical-header-right-aligned-page-template.php
+++ b/patterns/vertical-header-right-aligned-page-template.php
@@ -29,36 +29,40 @@
 	<!-- /wp:column -->
 	<!-- wp:column {"width":"90%","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50","left":"0","right":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-column" style="padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:0;flex-basis:90%">
-		<!-- wp:post-featured-image {"aspectRatio":"16/9","height":""} /-->
-		<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
-		<div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-			<!-- /wp:spacer -->
-			<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"top"}} -->
-			<div class="wp-block-group">
-				<!-- wp:post-title {"style":{"layout":{"selfStretch":"fixed","flexSize":"70vw"}},"fontSize":"xx-large"} /-->
+		<!-- wp:group {"tagName":"main","layout":{"type":"default"}} -->
+		<main class="wp-block-group">
+			<!-- wp:post-featured-image {"aspectRatio":"16/9","height":""} /-->
+			<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
+			<div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
+				<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+				<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"top"}} -->
+				<div class="wp-block-group">
+					<!-- wp:post-title {"style":{"layout":{"selfStretch":"fixed","flexSize":"70vw"}},"fontSize":"xx-large"} /-->
+				</div>
+				<!-- /wp:group -->
+				<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
+				<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
+
+				<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|70"}}}} -->
+				<div class="wp-block-columns">
+					<!-- wp:column {"width":"75%","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|60"}}}} -->
+					<div class="wp-block-column" style="padding-bottom:var(--wp--preset--spacing--60);flex-basis:75%">
+						<!-- wp:post-content {"layout":{"type":"default"}} /-->
+					</div>
+					<!-- /wp:column -->
+					<!-- wp:column {"width":"25%"} -->
+					<div class="wp-block-column" style="flex-basis:25%">
+					<!-- wp:template-part {"slug":"right-aligned-sidebar"} /-->
+					</div>
+					<!-- /wp:column -->
+				</div>
+				<!-- /wp:columns -->
 			</div>
 			<!-- /wp:group -->
-			<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
-			<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
-			<!-- /wp:spacer -->
-
-			<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|70"}}}} -->
-			<div class="wp-block-columns">
-				<!-- wp:column {"width":"75%","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|60"}}}} -->
-				<div class="wp-block-column" style="padding-bottom:var(--wp--preset--spacing--60);flex-basis:75%">
-					<!-- wp:post-content {"layout":{"type":"default"}} /-->
-				</div>
-				<!-- /wp:column -->
-				<!-- wp:column {"width":"25%"} -->
-				<div class="wp-block-column" style="flex-basis:25%">
-				<!-- wp:template-part {"slug":"right-aligned-sidebar"} /-->
-				</div>
-				<!-- /wp:column -->
-			</div>
-			<!-- /wp:columns -->
-		</div>
+		</main>
 		<!-- /wp:group -->
 	</div>
 	<!-- /wp:column -->

--- a/patterns/vertical-header-right-aligned-post-template.php
+++ b/patterns/vertical-header-right-aligned-post-template.php
@@ -30,67 +30,71 @@
 	<!-- /wp:column -->
 	<!-- wp:column {"width":"90%","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--50);padding-right:0;padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50);flex-basis:90%">
-		<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"0"}}},"layout":{"type":"default"}} -->
-		<div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--50);padding-left:0">
-			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-			<!-- /wp:spacer -->
-			<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"top"}} -->
-			<div class="wp-block-group">
-				<!-- wp:post-title {"style":{"layout":{"selfStretch":"fixed","flexSize":"70vw"}},"fontSize":"xx-large"} /-->
-				<!-- wp:post-date {"textAlign":"right","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast","fontSize":"small"} /-->
-				</div>
-			<!-- /wp:group -->
-
-			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-			<!-- /wp:spacer -->
-		</div>
-		<!-- /wp:group -->
-		<!-- wp:post-featured-image {"aspectRatio":"16/9"} /-->
-		<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
-		<div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--50)">
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">
-				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<!-- wp:group {"tagName":"main","layout":{"type":"default"}} -->
+		<main class="wp-block-group">
+			<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"0"}}},"layout":{"type":"default"}} -->
+			<div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--50);padding-left:0">
+				<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+				<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"top"}} -->
 				<div class="wp-block-group">
-					<!-- wp:avatar {"size":30,"style":{"border":{"radius":"100px"}}} /-->
-					<!-- wp:post-author-name {"fontSize":"small"} /-->
+					<!-- wp:post-title {"style":{"layout":{"selfStretch":"fixed","flexSize":"70vw"}},"fontSize":"xx-large"} /-->
+					<!-- wp:post-date {"textAlign":"right","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast","fontSize":"small"} /-->
+					</div>
+				<!-- /wp:group -->
+
+				<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+				<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
+			</div>
+			<!-- /wp:group -->
+			<!-- wp:post-featured-image {"aspectRatio":"16/9"} /-->
+			<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
+			<div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--50)">
+				<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+				<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">
+					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+					<div class="wp-block-group">
+						<!-- wp:avatar {"size":30,"style":{"border":{"radius":"100px"}}} /-->
+						<!-- wp:post-author-name {"fontSize":"small"} /-->
+					</div>
+					<!-- /wp:group -->
+					<!-- wp:post-terms {"term":"post_tag","separator":"  ","className":"is-style-post-terms-1","style":{"typography":{"fontStyle":"normal","fontWeight":"400"}}} /-->
 				</div>
 				<!-- /wp:group -->
-				<!-- wp:post-terms {"term":"post_tag","separator":"  ","className":"is-style-post-terms-1","style":{"typography":{"fontStyle":"normal","fontWeight":"400"}}} /-->
+
+				<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+				<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
+
+				<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|70"}}}} -->
+				<div class="wp-block-columns">
+					<!-- wp:column {"width":"75%","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|60"}}}} -->
+					<div class="wp-block-column" style="padding-bottom:var(--wp--preset--spacing--60);flex-basis:75%">
+						<!-- wp:post-content {"layout":{"type":"default"}} /-->
+					</div>
+					<!-- /wp:column -->
+					<!-- wp:column {"width":"25%"} -->
+					<div class="wp-block-column" style="flex-basis:25%">
+						<!-- wp:template-part {"slug":"right-aligned-sidebar"} /-->
+					</div>
+					<!-- /wp:column -->
+				</div>
+				<!-- /wp:columns -->
+
+				<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+				<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
 			</div>
 			<!-- /wp:group -->
-
-			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-			<!-- /wp:spacer -->
-
-			<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|70"}}}} -->
-			<div class="wp-block-columns">
-				<!-- wp:column {"width":"75%","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|60"}}}} -->
-				<div class="wp-block-column" style="padding-bottom:var(--wp--preset--spacing--60);flex-basis:75%">
-					<!-- wp:post-content {"layout":{"type":"default"}} /-->
-				</div>
-				<!-- /wp:column -->
-				<!-- wp:column {"width":"25%"} -->
-				<div class="wp-block-column" style="flex-basis:25%">
-					<!-- wp:template-part {"slug":"right-aligned-sidebar"} /-->
-				</div>
-				<!-- /wp:column -->
-			</div>
-			<!-- /wp:columns -->
-
-			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-			<!-- /wp:spacer -->
-		</div>
-		<!-- /wp:group -->
-		<!-- wp:group {"tagName":"nav","align":"full","style":{"border":{"top":{"color":"var:preset|color|opacity-20","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
-		<nav class="wp-block-group alignfull" aria-label="Posts navigation" style="border-top-color:var(--wp--preset--color--opacity-20);border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
-			<!-- wp:post-navigation-link {"type":"previous","showTitle":true,"arrow":"arrow"} /-->
-			<!-- wp:post-navigation-link {"showTitle":true,"arrow":"arrow"} /-->
-		</nav>
+			<!-- wp:group {"tagName":"nav","align":"full","style":{"border":{"top":{"color":"var:preset|color|opacity-20","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+			<nav class="wp-block-group alignfull" aria-label="Posts navigation" style="border-top-color:var(--wp--preset--color--opacity-20);border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
+				<!-- wp:post-navigation-link {"type":"previous","showTitle":true,"arrow":"arrow"} /-->
+				<!-- wp:post-navigation-link {"showTitle":true,"arrow":"arrow"} /-->
+			</nav>
+			<!-- /wp:group -->
+		</main>
 		<!-- /wp:group -->
 	</div>
 	<!-- /wp:column -->

--- a/patterns/vertical-header-right-aligned-search-results-template.php
+++ b/patterns/vertical-header-right-aligned-search-results-template.php
@@ -35,18 +35,22 @@
 
 	<!-- wp:column {"width":"90%","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50);flex-basis:90%">
-		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-		<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
-		<!-- wp:query-title {"type":"search","fontSize":"large"} /-->
-		<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","style":{"border":{"radius":"50px"}},"fontSize":"small","borderColor":"opacity-20"} /-->
-		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-		<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
-		<!-- wp:pattern {"slug":"twentytwentyfive/right-aligned-posts"} /-->
-		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-		<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
+		<!-- wp:group {"tagName":"main","layout":{"type":"default"}} -->
+		<main class="wp-block-group">
+			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+			<!-- wp:query-title {"type":"search","fontSize":"large"} /-->
+			<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","style":{"border":{"radius":"50px"}},"fontSize":"small","borderColor":"opacity-20"} /-->
+			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+			<!-- wp:pattern {"slug":"twentytwentyfive/right-aligned-posts"} /-->
+			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+		</main>
+		<!-- /wp:group -->
 	</div>
 	<!-- /wp:column -->
 </div>


### PR DESCRIPTION
**Description**
Adds the missing main elements to template patterns with the name starting with vertical-header-right
Issue #278 

> * [ ]  vertical-header-right-aligned-archive-template, Archive for the right aligned blog
> * [ ]  vertical-header-right-aligned-home-template.php Homepage for right aligned blog
> * [ ]  vertical-header-right-aligned-page-template.php  Page template for the right aligned blog
> * [ ]  vertical-header-right-aligned-post-template.php
> * [ ]  vertical-header-right-aligned-search-results-template.php

Attention @carolinan wrote vertical-header-right-aligned-posts.php, but I think she meant vertical-header-right-aligned-post-template.php
I don't think in posts.php there is a main necessary. 

I added a group block in the right column with the main tag. I think that should be the right way to do it. 
We could rename this Group to Main like the Header group. But in the other templates, the main is not named. Therefore, I didn't add it.

**Screenshots**

![image](https://github.com/user-attachments/assets/9d96479b-1597-4556-a32d-baea84e7cb11)

