### PR TITLE
Fix pill border color style, add missing pill and miscellaneous adjustments.

### DIFF
--- a/patterns/banner-with-description-and-images-grid.php
+++ b/patterns/banner-with-description-and-images-grid.php
@@ -19,8 +19,8 @@
 		<div class="wp-block-group">
 			<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
 			<div class="wp-block-group">
-				<!-- wp:heading {"className":"is-style-pill","fontSize":"small"} -->
-				<h2 class="wp-block-heading is-style-pill has-small-font-size">About Us</h2>
+				<!-- wp:heading {"className":"is-style-pill"} -->
+				<h2 class="wp-block-heading is-style-pill">About Us</h2>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph -->

--- a/patterns/banner-with-description-and-images-grid.php
+++ b/patterns/banner-with-description-and-images-grid.php
@@ -11,16 +11,16 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"},"blockGap":"var:preset|spacing|60"}},"layout":{"type":"grid","minimumColumnWidth":"32rem"}} -->
 	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 		<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between","justifyContent":"stretch"}} -->
 		<div class="wp-block-group">
-			<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+			<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
 			<div class="wp-block-group">
-				<!-- wp:heading {"fontSize":"small"} -->
-				<h2 class="wp-block-heading has-small-font-size">About Us</h2>
+				<!-- wp:heading {"className":"is-style-pill","fontSize":"small"} -->
+				<h2 class="wp-block-heading is-style-pill has-small-font-size">About Us</h2>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph -->

--- a/patterns/grid-videos.php
+++ b/patterns/grid-videos.php
@@ -11,16 +11,16 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|60"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|60","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 	<div class="wp-block-group alignwide">
 		<!-- wp:heading {"textAlign":"left","level":3,"align":"wide","style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
 		<h3 class="wp-block-heading alignwide has-text-align-left">Explore the episodes</h3>
 		<!-- /wp:heading -->
 
-		<!-- wp:paragraph {"className":"is-style-pill","fontSize":"small"} -->
-		<p class="is-style-pill has-small-font-size">Podcast</p>
+		<!-- wp:paragraph {"className":"is-style-pill"} -->
+		<p class="is-style-pill">Podcast</p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/patterns/page-coming-soon.php
+++ b/patterns/page-coming-soon.php
@@ -21,8 +21,8 @@
 
 		<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 		<div class="wp-block-group">
-			<!-- wp:heading {"textAlign":"center","level":1,"className":"is-style-pill","fontSize":"small","borderColor":"accent-1"} -->
-			<h1 class="wp-block-heading has-text-align-center is-style-pill has-border-color has-accent-1-border-color has-small-font-size">Event</h1>
+			<!-- wp:heading {"textAlign":"center","level":1,"className":"is-style-pill"} -->
+			<h1 class="wp-block-heading has-text-align-center is-style-pill">Event</h1>
 			<!-- /wp:heading -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/photo-blog-home-template.php
+++ b/patterns/photo-blog-home-template.php
@@ -18,8 +18,8 @@
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
 	<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 	<div class="wp-block-group">
-		<!-- wp:heading {"textAlign":"center","level":1,"className":"is-style-pill","fontSize":"small"} -->
-		<h1 class="wp-block-heading has-text-align-center is-style-pill has-small-font-size">Stories</h1>
+		<!-- wp:heading {"textAlign":"center","level":1,"className":"is-style-pill"} -->
+		<h1 class="wp-block-heading has-text-align-center is-style-pill">Stories</h1>
 		<!-- /wp:heading -->
 	</div>
 	<!-- /wp:group -->

--- a/styles/blocks/pill.json
+++ b/styles/blocks/pill.json
@@ -11,7 +11,7 @@
 			"letterSpacing": "normal"
 		},
 		"border": {
-			"color": "var:preset|color|contrast",
+			"color": "currentColor",
 			"style": "solid",
 			"width": "1px",
 			"radius": "999px"


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

- Set the border color of the pill style variation to be `currentColor` to make it work well with the different style variations.
- "Banner with description and images grid": Added pill style, added margin zero from outer group.
- "Grid Videos": Added margin zero from outer group. Removed font size from pill styled element as it already comes from the variation.
"Page coming soon": The border color was removed from the pill style, as the variation now uses `currentColor`.
"Photo blog home template": The font size was removed from the pill-styled element as it already comes from the variation.  

**Screenshots**

https://github.com/user-attachments/assets/e32c5397-589a-45c3-b2f5-8d156e3b0d83

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**

*Patterns*

1. Create a page and add the following patterns: Banner with description and images grid, Grid videos, page coming soon.
2. Try different style variations and confirm there's no white space between them, and the pill styles (font size and border) are looking well with the different variations.

*Home template*.

1. Open the site editor
2. Select the Blog home, and apply the "Photo blog home" design. Confirm the pill style font size is looking well.