### PR TITLE
Remove all Categories: hidden in the pattern files

### DIFF
--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -2,7 +2,6 @@
 /**
  * Title: Sidebar
  * Slug: twentytwentyfive/hidden-sidebar
- * Categories: hidden
  * Inserter: no
  *
  * @package WordPress

--- a/patterns/news-blog-home-template.php
+++ b/patterns/news-blog-home-template.php
@@ -3,7 +3,6 @@
  * Title: News blog home
  * Slug: twentytwentyfive/news-blog-home
  * Template Types: front-page, index, home
- * Categories: hidden
  * Inserter: no
  *
  * @package WordPress

--- a/patterns/news-blog-with-featured-posts-grid-template.php
+++ b/patterns/news-blog-with-featured-posts-grid-template.php
@@ -3,7 +3,6 @@
  * Title: News blog with featured posts grid
  * Slug: twentytwentyfive/news-blog-with-featured-posts-grid-template
  * Template Types: front-page, index, home
- * Categories: hidden
  * Inserter: no
  *
  * @package WordPress

--- a/patterns/news-blog-with-sidebar-template.php
+++ b/patterns/news-blog-with-sidebar-template.php
@@ -3,7 +3,6 @@
  * Title: News blog with sidebar
  * Slug: twentytwentyfive/news-blog-with-sidebar-template
  * Template Types: front-page, index, home
- * Categories: hidden
  * Inserter: no
  *
  * @package WordPress

--- a/patterns/offset-post-no-featured-image-template.php
+++ b/patterns/offset-post-no-featured-image-template.php
@@ -4,7 +4,6 @@
  * Slug: twentytwentyfive/offset-post-no-featured-image-template
  * Template Types: posts, single
  * Viewport width: 1400
- * Categories: hidden
  * Inserter: no
  *
  * @package WordPress

--- a/patterns/post-with-left-aligned-content.php
+++ b/patterns/post-with-left-aligned-content.php
@@ -4,7 +4,6 @@
  * Slug: twentytwentyfive/post-with-left-aligned-content
  * Template Types: posts, single
  * Viewport width: 1400
- * Categories: hidden
  * Inserter: no
  *
  * @package WordPress

--- a/patterns/vertical-header-right-aligned-sidebar.php
+++ b/patterns/vertical-header-right-aligned-sidebar.php
@@ -2,7 +2,6 @@
 /**
  * Title: Sidebar for the right aligned blog
  * Slug: twentytwentyfive/right-aligned-sidebar
- * Categories: hidden
  * Inserter: no
  *
  * @package WordPress


### PR DESCRIPTION
Removes all locations where Categories: hidden was placed by the create block theme plugin.
Should solve the Issue #259 