### PR TITLE
Add landing page for podcast and event

### DIFF
--- a/patterns/page-landing-event.php
+++ b/patterns/page-landing-event.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Title: Landing page for Event
+ * Slug: twentytwentyfive/page-landing-event
+ * Categories: twentytwentyfive_page, featured
+ * Keywords: starter
+ * Block Types: core/post-content
+ * Post Types: page, wp_template
+ * Viewport width: 1400
+ * Description: .
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+
+<!-- wp:pattern {"slug":"twentytwentyfive/hero-full-width-image"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfive/heading-and-paragraph-with-image"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfive/two-headings-and-a-list"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfive/text-faqs"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfive/banner-description-images-grid"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfive/contact-centered-social-link"} /-->

--- a/patterns/page-landing-podcast.php
+++ b/patterns/page-landing-podcast.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Title: Landing page for Podcast
+ * Slug: twentytwentyfive/page-landing-podcast
+ * Categories: twentytwentyfive_page, featured
+ * Keywords: starter
+ * Block Types: core/post-content
+ * Post Types: page, wp_template
+ * Viewport width: 1400
+ * Description: .
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+
+<!-- wp:pattern {"slug":"twentytwentyfive/hero-podcast"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfive/heading-and-paragraph-with-image"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfive/clients-section"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfive/grid-videos"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfive/newsletter-sign-up"} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Add landing pages for podcast and event.

Figma links:

- [Landing page: product/event](https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=1-3413&t=kxoQKmyP8HzgJJSC-1)
- [Landing page: Podcast](https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=1-3420&t=kxoQKmyP8HzgJJSC-1)

The only difference between the designs is that the "About the event" section for the "Landing podcast" has the default variation, and I don't know if that's possible. cc @carolinan 

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

https://github.com/user-attachments/assets/c4da94cf-4e65-4b05-9a53-094559ee2fba


**Testing Instructions**

1. Create a page.
2. Select the Landing page podcast and confirm that it's using the right patterns and in the same order
3. Repeat the same with the "Landing page for Event".