### PR TITLE
Fix heading sizes, to use custom sizes and match designs.

### DIFF
--- a/patterns/clients-section.php
+++ b/patterns/clients-section.php
@@ -15,8 +15,8 @@
 <div class="wp-block-group alignfull is-style-section-5" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--50)">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
-		<!-- wp:heading {"textAlign":"center","level":3} -->
-		<h3 class="wp-block-heading has-text-align-center">The Stories Podcast is sponsored by</h3>
+		<!-- wp:heading {"textAlign":"center"} -->
+		<h2 class="wp-block-heading has-text-align-center">The Stories Podcast is sponsored by</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|20","padding":{"right":"0","left":"0","top":"var:preset|spacing|50","bottom":"0"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->

--- a/patterns/cta-pricing.php
+++ b/patterns/cta-pricing.php
@@ -16,8 +16,8 @@
 <div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 	<div class="wp-block-group alignwide" style="padding-bottom:var(--wp--preset--spacing--50)">
-		<!-- wp:heading {"textAlign":"center","align":"wide"} -->
-		<h2 class="wp-block-heading alignwide has-text-align-center">Pricing</h2>
+		<!-- wp:heading {"textAlign":"center","align":"wide","style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-1)"}}} -->
+		<h2 class="wp-block-heading alignwide has-text-align-center" style="font-size:var(--wp--custom--font-size--heading-1);">Pricing</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center"} -->
@@ -38,8 +38,8 @@
 
 		<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}},"border":{"width":"1px","color":"var:preset|color|opacity-20","radius":"10px"}}} -->
 		<div class="wp-block-column has-border-color" style="border-color:var(--wp--preset--color--opacity-20);border-width:1px;border-radius:10px;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-			<!-- wp:heading {"level":3} -->
-			<h3 class="wp-block-heading" id="free">Free</h3>
+			<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-2)"}}} -->
+			<h3 class="wp-block-heading" id="free" style="font-size:var(--wp--custom--font-size--heading-2);">Free</h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"large"} -->
@@ -82,8 +82,8 @@
 
 		<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}},"border":{"width":"1px","color":"var:preset|color|opacity-20","radius":"10px"}},"layout":{"type":"default"}} -->
 		<div class="wp-block-column has-border-color" style="border-color:var(--wp--preset--color--opacity-20);border-width:1px;border-radius:10px;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-			<!-- wp:heading {"level":3} -->
-			<h3 class="wp-block-heading" id="single">Single</h3>
+			<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-2)"}}} -->
+			<h3 class="wp-block-heading" id="single" style="font-size:var(--wp--custom--font-size--heading-2);">Single</h3>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"fontSize":"large"} -->

--- a/patterns/event-schedule.php
+++ b/patterns/event-schedule.php
@@ -16,8 +16,8 @@
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide">
-		<!-- wp:heading {"fontSize":"xx-large"} -->
-		<h2 class="wp-block-heading has-xx-large-font-size">Agenda</h2>
+		<!-- wp:heading {"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-1)"}}} -->
+		<h2 class="wp-block-heading" style="font-size:var(--wp--custom--font-size--heading-1);">Agenda</h2>
 		<!-- /wp:heading -->
 		<!-- wp:paragraph -->
 		<p>These are some of the upcoming events.</p>

--- a/patterns/events-list-with-cta.php
+++ b/patterns/events-list-with-cta.php
@@ -13,8 +13,9 @@
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-	<div class="wp-block-group alignwide"><!-- wp:heading -->
-		<h2 class="wp-block-heading">Upcoming events</h2>
+	<div class="wp-block-group alignwide">
+		<!-- wp:heading {"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-1)"}}} -->
+		<h2 class="wp-block-heading" style="font-size:var(--wp--custom--font-size--heading-1);">Upcoming events</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph -->
@@ -24,8 +25,9 @@
 		<!-- wp:group {"style":{"spacing":{"blockGap":"0","margin":{"top":"var:preset|spacing|70"}}},"layout":{"type":"default"}} -->
 		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70)"><!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:group {"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group"><!-- wp:heading {"level":3} -->
-					<h3 class="wp-block-heading">Tell your story</h3>
+				<div class="wp-block-group">
+					<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-2)"}}} -->
+					<h3 class="wp-block-heading" id="single" style="font-size:var(--wp--custom--font-size--heading-2);">Tell your story</h3>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->
@@ -35,7 +37,8 @@
 				<!-- /wp:group -->
 
 				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|70"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-				<div class="wp-block-group"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
 					<p style="text-transform:uppercase">Mon, Jan 1</p>
 					<!-- /wp:paragraph -->
 
@@ -52,8 +55,9 @@
 
 			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|opacity-20","width":"1px"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 			<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--opacity-20);border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:group {"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group"><!-- wp:heading {"level":3} -->
-					<h3 class="wp-block-heading">“Stories, historias, iсторії, iστορίες”</h3>
+				<div class="wp-block-group">
+					<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-2)"}}} -->
+					<h3 class="wp-block-heading" id="single" style="font-size:var(--wp--custom--font-size--heading-2);">“Stories, historias, iсторії, iστορίες”</h3>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->
@@ -63,7 +67,8 @@
 				<!-- /wp:group -->
 
 				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|70"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-				<div class="wp-block-group"><!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"style":{"typography":{"textTransform":"uppercase"}}} -->
 					<p style="text-transform:uppercase">Mon, Jan 1</p>
 					<!-- /wp:paragraph -->
 
@@ -80,8 +85,9 @@
 
 			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|opacity-20","width":"1px"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 			<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--opacity-20);border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:group {"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group"><!-- wp:heading {"level":3} -->
-					<h3 class="wp-block-heading">Tell your story</h3>
+				<div class="wp-block-group">
+					<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-2)"}}} -->
+					<h3 class="wp-block-heading" id="single" style="font-size:var(--wp--custom--font-size--heading-2);">Tell your story</h3>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->
@@ -108,8 +114,9 @@
 
 			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|opacity-20","width":"1px"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 			<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--opacity-20);border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:group {"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group"><!-- wp:heading {"level":3} -->
-					<h3 class="wp-block-heading">“Stories, historias, iсторії, iστορίες”</h3>
+				<div class="wp-block-group">
+					<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-2)"}}} -->
+					<h3 class="wp-block-heading" id="single" style="font-size:var(--wp--custom--font-size--heading-2);">“Stories, historias, iсторії, iστορίες”</h3>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->

--- a/patterns/events-three-columns-images-and-titles.php
+++ b/patterns/events-three-columns-images-and-titles.php
@@ -13,75 +13,93 @@
 
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"0","margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left"}} -->
-<div class="wp-block-group alignwide"><!-- wp:heading {"fontSize":"x-large"} -->
-<h2 class="wp-block-heading has-x-large-font-size"><?php esc_html_e( 'Events', 'twentytwentyfive' ); ?></h2>
-<!-- /wp:heading -->
+<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:0px;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+	<!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left"}} -->
+	<div class="wp-block-group alignwide">
+		<!-- wp:heading {"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-1)"}}} -->
+		<h2 class="wp-block-heading" style="font-size:var(--wp--custom--font-size--heading-1);"><?php esc_html_e( 'Events', 'twentytwentyfive' ); ?></h2>
+		<!-- /wp:heading -->
 
-<!-- wp:paragraph -->
-<p><?php esc_html_e( 'These are some of the upcoming events.', 'twentytwentyfive' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
+		<!-- wp:paragraph -->
+		<p><?php esc_html_e( 'These are some of the upcoming events.', 'twentytwentyfive' ); ?></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
 
-<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"var:preset|spacing|50"},"padding":{"top":"0","bottom":"0"}}}} -->
-<div class="wp-block-columns alignwide" style="padding-top:0;padding-bottom:0"><!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70"},"blockGap":"0"}}} -->
-<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--70)"><!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/image-from-rawpixel-id-8802835-jpeg-scaled.webp' ); ?>" alt="Event image" /></figure>
-<!-- /wp:image -->
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"0","left":"var:preset|spacing|50"},"padding":{"top":"0","bottom":"0"}}}} -->
+	<div class="wp-block-columns alignwide" style="padding-top:0;padding-bottom:0">
+		<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70"},"blockGap":"0"}}} -->
+		<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--70)">
+			<!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+			<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/image-from-rawpixel-id-8802835-jpeg-scaled.webp' ); ?>" alt="Event image" /></figure>
+			<!-- /wp:image -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20","padding":{"top":"var:preset|spacing|30"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"}}}} -->
-<h3 class="wp-block-heading" style="padding-top:var(--wp--preset--spacing--20)"><?php esc_html_e( 'Tell your story', 'twentytwentyfive' ); ?></h3>
-<!-- /wp:heading -->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20","padding":{"top":"var:preset|spacing|30"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30)">
+				<!-- wp:heading {"level":3,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"}},"typography":{"fontSize":"var(--wp--custom--font-size--heading-2)"}}} -->
+				<h3 class="wp-block-heading" style="padding-top:var(--wp--preset--spacing--20);font-size:var(--wp--custom--font-size--heading-2);"><?php esc_html_e( 'Tell your story', 'twentytwentyfive' ); ?></h3>
+				<!-- /wp:heading -->
 
-<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"medium"} -->
-<p class="has-primary-color has-text-color has-link-color has-medium-font-size"><?php esc_html_e( 'September 2, 2024', 'twentytwentyfive' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
+				<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"medium"} -->
+				<p class="has-primary-color has-text-color has-link-color has-medium-font-size"><?php esc_html_e( 'September 2, 2024', 'twentytwentyfive' ); ?></p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
 
-<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}}} -->
-<p style="padding-top:var(--wp--preset--spacing--40)"><a href="#"><?php esc_html_e( 'Event details', 'twentytwentyfive' ); ?></a></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:column -->
+			<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}}} -->
+			<p style="padding-top:var(--wp--preset--spacing--40)"><a href="#"><?php esc_html_e( 'Event details', 'twentytwentyfive' ); ?></a></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
 
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70"},"blockGap":"0"}}} -->
-<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--70)"><!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/image-from-rawpixel-id-8802835-jpeg-scaled.webp' ); ?>" alt="Event image" /></figure>
-<!-- /wp:image -->
+		<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70"},"blockGap":"0"}}} -->
+		<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--70)">
+			<!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+			<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/image-from-rawpixel-id-8802835-jpeg-scaled.webp' ); ?>" alt="Event image" /></figure>
+			<!-- /wp:image -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20","padding":{"top":"var:preset|spacing|30"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"}}}} -->
-<h3 class="wp-block-heading" style="padding-top:var(--wp--preset--spacing--20)"><?php esc_html_e( 'Tell your story', 'twentytwentyfive' ); ?></h3>
-<!-- /wp:heading -->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20","padding":{"top":"var:preset|spacing|30"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30)">
+				<!-- wp:heading {"level":3,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"}},"typography":{"fontSize":"var(--wp--custom--font-size--heading-2)"}}} -->
+				<h3 class="wp-block-heading" style="padding-top:var(--wp--preset--spacing--20);font-size:var(--wp--custom--font-size--heading-2);"><?php esc_html_e( 'Tell your story', 'twentytwentyfive' ); ?></h3>
+				<!-- /wp:heading -->
 
-<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"medium"} -->
-<p class="has-primary-color has-text-color has-link-color has-medium-font-size"><?php esc_html_e( 'September 2, 2024', 'twentytwentyfive' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
+				<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"medium"} -->
+				<p class="has-primary-color has-text-color has-link-color has-medium-font-size"><?php esc_html_e( 'September 2, 2024', 'twentytwentyfive' ); ?></p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
 
-<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}}} -->
-<p style="padding-top:var(--wp--preset--spacing--40)"><a href="#"><?php esc_html_e( 'Event details', 'twentytwentyfive' ); ?></a></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:column -->
+			<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}}} -->
+			<p style="padding-top:var(--wp--preset--spacing--40)"><a href="#"><?php esc_html_e( 'Event details', 'twentytwentyfive' ); ?></a></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
 
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70"},"blockGap":"0"}}} -->
-<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--70)"><!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/image-from-rawpixel-id-8802835-jpeg-scaled.webp' ); ?>" alt="Event image" /></figure>
-<!-- /wp:image -->
+		<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70"},"blockGap":"0"}}} -->
+		<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--70)">
+			<!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+			<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/image-from-rawpixel-id-8802835-jpeg-scaled.webp' ); ?>" alt="Event image" /></figure>
+			<!-- /wp:image -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20","padding":{"top":"var:preset|spacing|30"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30)"><!-- wp:heading {"level":3,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"}}}} -->
-<h3 class="wp-block-heading" style="padding-top:var(--wp--preset--spacing--20)"><?php esc_html_e( 'Tell your story', 'twentytwentyfive' ); ?></h3>
-<!-- /wp:heading -->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20","padding":{"top":"var:preset|spacing|30"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30)">
+				<!-- wp:heading {"level":3,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"}},"typography":{"fontSize":"var(--wp--custom--font-size--heading-2)"}}} -->
+				<h3 class="wp-block-heading" style="padding-top:var(--wp--preset--spacing--20);font-size:var(--wp--custom--font-size--heading-2);"><?php esc_html_e( 'Tell your story', 'twentytwentyfive' ); ?></h3>
+				<!-- /wp:heading -->
 
-<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"medium"} -->
-<p class="has-primary-color has-text-color has-link-color has-medium-font-size"><?php esc_html_e( 'September 2, 2024', 'twentytwentyfive' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
+				<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|primary"}}}},"textColor":"primary","fontSize":"medium"} -->
+				<p class="has-primary-color has-text-color has-link-color has-medium-font-size"><?php esc_html_e( 'September 2, 2024', 'twentytwentyfive' ); ?></p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
 
-<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}}} -->
-<p style="padding-top:var(--wp--preset--spacing--40)"><a href="#"><?php esc_html_e( 'Event details', 'twentytwentyfive' ); ?></a></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
+			<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}}} -->
+			<p style="padding-top:var(--wp--preset--spacing--40)"><a href="#"><?php esc_html_e( 'Event details', 'twentytwentyfive' ); ?></a></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+</div>
 <!-- /wp:group -->

--- a/patterns/grid-videos.php
+++ b/patterns/grid-videos.php
@@ -15,8 +15,8 @@
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 	<div class="wp-block-group alignwide">
-		<!-- wp:heading {"textAlign":"left","level":3,"align":"wide","style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
-		<h3 class="wp-block-heading alignwide has-text-align-left">Explore the episodes</h3>
+		<!-- wp:heading {"textAlign":"left","align":"wide","style":{"layout":{"selfStretch":"fit","flexSize":null},"typography":{"fontSize":"var(--wp--custom--font-size--heading-1)"}}} -->
+		<h2 class="wp-block-heading alignwide has-text-align-left" style="font-size:var(--wp--custom--font-size--heading-1);">Explore the episodes</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"className":"is-style-pill","fontSize":"small"} -->

--- a/patterns/grid-with-categories.php
+++ b/patterns/grid-with-categories.php
@@ -17,8 +17,8 @@
 	<div class="wp-block-group alignwide">
 		<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","verticalAlignment":"center"}} -->
 		<div class="wp-block-group">
-			<!-- wp:heading {"fontSize":"x-large"} -->
-			<h2 class="wp-block-heading has-x-large-font-size">Top Categories</h2>
+			<!-- wp:heading {"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-3)"}}} -->
+			<h2 class="wp-block-heading" style="font-size:var(--wp--custom--font-size--heading-3);">Top Categories</h2>
 			<!-- /wp:heading -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/heading-and-paragraph-with-image.php
+++ b/patterns/heading-and-paragraph-with-image.php
@@ -17,10 +17,8 @@
 	<div class="wp-block-columns alignwide">
 		<!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
-			<!-- wp:heading {"level":3,"className":"wp-block-heading"} -->
-			<h3 class="wp-block-heading">
-				<?php esc_html_e( 'About the Event', 'twentytwentyfive' ); ?>
-			</h3>
+			<!-- wp:heading {"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-1)"}}} -->
+			<h2 class="wp-block-heading" style="font-size:var(--wp--custom--font-size--heading-1);"><?php esc_html_e( 'About the Event', 'twentytwentyfive' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"fontSize":"medium"} -->
@@ -31,7 +29,7 @@
 		<!-- /wp:column -->
 
 		<!-- wp:column {"verticalAlignment":"center","width":"50%","layout":{"type":"default"}} -->
-		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"> 
+		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
 			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full"} -->
 			<figure class="wp-block-image size-full">
 				<img src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/image-from-rawpixel-id-8803077-original.webp' ); ?>" alt="<?php echo esc_attr_x( 'A classic black and white photo of an old church', 'Alt text for Overview picture', 'twentytwentyfive' ); ?>" style="aspect-ratio:1;object-fit:cover" />

--- a/patterns/hero-centered-heading.php
+++ b/patterns/hero-centered-heading.php
@@ -15,8 +15,8 @@
 <div class="wp-block-group alignfull" style="min-height:0vh;margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--40);">
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
-		<!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"right":"0","left":"0"},"padding":{"right":"0","left":"0"}}}} -->
-		<h1 class="wp-block-heading has-text-align-center" style="margin-right:0;margin-left:0;padding-right:0;padding-left:0">Tell your story</h1>
+		<!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"right":"0","left":"0"},"padding":{"right":"0","left":"0"}},"typography":{"fontSize":"var(--wp--custom--font-size--heading-1)"}}} -->
+		<h2 class="wp-block-heading has-text-align-center" style="margin-right:0;margin-left:0;padding-right:0;padding-left:0;font-size:var(--wp--custom--font-size--heading-1);">Tell your story</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center"} -->

--- a/patterns/hero-podcast.php
+++ b/patterns/hero-podcast.php
@@ -27,8 +27,8 @@
 
 		<!-- wp:column {"verticalAlignment":"center","width":"60%"} -->
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:60%">
-			<!-- wp:heading {"fontSize":"xx-large"} -->
-			<h2 class="wp-block-heading has-xx-large-font-size">The Stories Podcast</h2>
+			<!-- wp:heading {"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-1)"}}} -->
+			<h2 class="wp-block-heading" style="font-size:var(--wp--custom--font-size--heading-1);">The Stories Podcast</h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30"}}}} -->

--- a/patterns/intro-short-heading-image.php
+++ b/patterns/intro-short-heading-image.php
@@ -27,8 +27,8 @@
 
 		<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} -->
 		<div class="wp-block-column is-vertically-aligned-center">
-			<!-- wp:heading -->
-			<h2 class="wp-block-heading"><?php echo esc_html_x( 'New arrivals', 'Heading for banner with flower', 'twentytwentyfive' ); ?></h2>
+			<!-- wp:heading {"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-1)"}}} -->
+			<h2 class="wp-block-heading" style="font-size:var(--wp--custom--font-size--heading-1);"><?php echo esc_html_x( 'New arrivals', 'Heading for banner with flower', 'twentytwentyfive' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"fontSize":"large"} -->

--- a/patterns/services-subscriber-only-section.php
+++ b/patterns/services-subscriber-only-section.php
@@ -12,53 +12,65 @@
 
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|50","padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|70","left":"var:preset|spacing|70"}}}} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center"} -->
-<div class="wp-block-column is-vertically-aligned-center"><!-- wp:heading {"fontSize":"xx-large"} -->
-<h2 class="wp-block-heading has-xx-large-font-size">Subscribe to get unlimited access</h2>
-<!-- /wp:heading -->
+<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|70","left":"var:preset|spacing|70"}}}} -->
+	<div class="wp-block-columns alignwide">
+		<!-- wp:column {"verticalAlignment":"center"} -->
+		<div class="wp-block-column is-vertically-aligned-center">
+			<!-- wp:heading {"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-1)"}}} -->
+			<h2 class="wp-block-heading" style="font-size:var(--wp--custom--font-size--heading-1);">Subscribe to get unlimited access</h2>
+			<!-- /wp:heading -->
 
-<!-- wp:list {"className":"is-style-checkmark-list","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"padding":{"left":"var:preset|spacing|30"}}}} -->
-<ul style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)" class="wp-block-list is-style-checkmark-list"><!-- wp:list-item {"fontSize":"medium"} -->
-<li class="has-medium-font-size">Get access to our paid articles and weekly newsletter.</li>
-<!-- /wp:list-item -->
+			<!-- wp:list {"className":"is-style-checkmark-list","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"padding":{"left":"var:preset|spacing|30"}}}} -->
+			<ul style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)" class="wp-block-list is-style-checkmark-list">
+				<!-- wp:list-item {"fontSize":"medium"} -->
+				<li class="has-medium-font-size">Get access to our paid articles and weekly newsletter.</li>
+				<!-- /wp:list-item -->
 
-<!-- wp:list-item {"fontSize":"medium"} -->
-<li class="has-medium-font-size">Join our IRL event.</li>
-<!-- /wp:list-item -->
+				<!-- wp:list-item {"fontSize":"medium"} -->
+				<li class="has-medium-font-size">Join our IRL event.</li>
+				<!-- /wp:list-item -->
 
-<!-- wp:list-item {"fontSize":"medium"} -->
-<li class="has-medium-font-size">Get a free tote bag.</li>
-<!-- /wp:list-item -->
+				<!-- wp:list-item {"fontSize":"medium"} -->
+				<li class="has-medium-font-size">Get a free tote bag.</li>
+				<!-- /wp:list-item -->
 
-<!-- wp:list-item {"fontSize":"medium"} -->
-<li class="has-medium-font-size">An elegant addition of home decor collection.</li>
-<!-- /wp:list-item -->
+				<!-- wp:list-item {"fontSize":"medium"} -->
+				<li class="has-medium-font-size">An elegant addition of home decor collection.</li>
+				<!-- /wp:list-item -->
 
-<!-- wp:list-item {"fontSize":"medium"} -->
-<li class="has-medium-font-size">Join our forums.</li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->
+				<!-- wp:list-item {"fontSize":"medium"} -->
+				<li class="has-medium-font-size">Join our forums.</li>
+				<!-- /wp:list-item -->
+			</ul>
+			<!-- /wp:list -->
 
-<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left","flexWrap":"nowrap"}} -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-fill"} -->
-<div class="wp-block-button is-style-fill"><a class="wp-block-button__link wp-element-button">Subscribe</a></div>
-<!-- /wp:button -->
+			<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left","flexWrap":"nowrap"}} -->
+			<div class="wp-block-buttons">
+				<!-- wp:button {"className":"is-style-fill"} -->
+				<div class="wp-block-button is-style-fill"><a class="wp-block-button__link wp-element-button">Subscribe</a></div>
+				<!-- /wp:button -->
 
-<!-- wp:button {"className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button">View plans</a></div>
-<!-- /wp:button --></div>
-<!-- /wp:buttons -->
+				<!-- wp:button {"className":"is-style-outline"} -->
+				<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button">View plans</a></div>
+				<!-- /wp:button -->
+			</div>
+			<!-- /wp:buttons -->
 
-<!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size">Cancel or pause anytime.</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:column -->
+			<!-- wp:paragraph {"fontSize":"small"} -->
+			<p class="has-small-font-size">Cancel or pause anytime.</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"center"} -->
-<div class="wp-block-column is-vertically-aligned-center"><!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/services-subscriber-photo.webp" alt="Smartphones capturing a scenic wildflower meadow with trees"/></figure>
-<!-- /wp:image --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
+		<!-- wp:column {"verticalAlignment":"center"} -->
+		<div class="wp-block-column is-vertically-aligned-center">
+			<!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
+			<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/services-subscriber-photo.webp" alt="Smartphones capturing a scenic wildflower meadow with trees"/></figure>
+			<!-- /wp:image -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+</div>
 <!-- /wp:group -->

--- a/patterns/services-team-photos.php
+++ b/patterns/services-team-photos.php
@@ -17,10 +17,8 @@
 	<div class="wp-block-columns alignwide">
 		<!-- wp:column -->
 		<div class="wp-block-column">
-			<!-- wp:heading {"level":3} -->
-			<h3 class="wp-block-heading">
-				Our small team is a group of driven, detail-oriented people who are passionate about their customers.
-			</h3>
+			<!-- wp:heading {"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-1)"}}} -->
+			<h2 class="wp-block-heading" style="font-size:var(--wp--custom--font-size--heading-1);">Our small team is a group of driven, detail-oriented people who are passionate about their customers.</h2>
 			<!-- /wp:heading -->
 		</div>
 		<!-- /wp:column -->

--- a/patterns/two-headings-and-a-list.php
+++ b/patterns/two-headings-and-a-list.php
@@ -17,10 +17,8 @@
 	<div class="wp-block-columns alignwide">
 		<!-- wp:column {"verticalAlignment":"top","width":"50%"} -->
 		<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:50%">
-			<!-- wp:heading {"level":3} -->
-			<h3 class="wp-block-heading">
-				<?php esc_html_e( 'Let’s hear about history and ancestry', 'twentytwentyfive' ); ?>
-			</h3>
+			<!-- wp:heading {"style":{"typography":{"fontSize":"var(--wp--custom--font-size--heading-1)"}}} -->
+			<h2 class="wp-block-heading" style="font-size:var(--wp--custom--font-size--heading-1);"><?php esc_html_e( 'Let’s hear about history and ancestry', 'twentytwentyfive' ); ?></h2>
 			<!-- /wp:heading -->
 		</div>
 		<!-- /wp:column -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Now that we have the [custom heading sizes](https://github.com/WordPress/twentytwentyfive/pull/269) we need to fix the font sizes and HTML elements for most of the patterns, to match the designs.

Partial for https://github.com/WordPress/twentytwentyfive/issues/186

Patterns:

- Clients section
- Pricing two columns
- Event schedule
- Events – List with Call to Action
- Grid with videos
- Grid with categories
- Hero Centered Heading
- Hero podcast
- Short heading and paragraph and image on the left
- Services - Team photos
- Two Headings and a List
- Heading and paragraph with image on the right
- Services - Subscriber only section
- Events three columns with event images and titles

**Screenshots**

N/A

**Testing Instructions**

- Create a page.
- Add the following patterns modified in this PR.
- Confirm that the headings are using the proper HTML elements (to improve a11y) and the same sizes as the designs.
