### PR TITLE
Add <main> to "Offset post without featured image"

### DIFF
--- a/patterns/offset-post-no-featured-image-template.php
+++ b/patterns/offset-post-no-featured-image-template.php
@@ -15,91 +15,118 @@
 <!-- wp:template-part {"slug":"header","area":"header"} /-->
 
 <!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide"><!-- wp:group {"className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|40"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}},"border":{"bottom":{"color":"var:preset|color|opacity-20","width":"1px"},"top":[],"right":[],"left":[]}},"layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide" style="border-bottom-color:var(--wp--preset--color--opacity-20);border-bottom-width:1px;padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:post-title {"level":1,"align":"wide","fontSize":"xx-large"} /-->
+<div class="wp-block-group alignwide">
+	<!-- wp:group {"className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|40"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--40)">
+		<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}},"border":{"bottom":{"color":"var:preset|color|opacity-20","width":"1px"},"top":[],"right":[],"left":[]}},"layout":{"type":"default"}} -->
+		<div class="wp-block-group alignwide" style="border-bottom-color:var(--wp--preset--color--opacity-20);border-bottom-width:1px;padding-bottom:var(--wp--preset--spacing--50)">
+			<!-- wp:post-title {"level":1,"align":"wide","fontSize":"xx-large"} /-->
+			<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
 
-<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
+	<!-- wp:group {"className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
+		<div class="wp-block-group alignwide">
+			<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|50"}}}} -->
+			<div class="wp-block-columns">
+				<!-- wp:column {"width":"30%"} -->
+				<div class="wp-block-column" style="flex-basis:30%">
+					<!-- wp:group {"style":{"spacing":{"blockGap":"4px"}},"fontSize":"small","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+					<div class="wp-block-group has-small-font-size">
+						<!-- wp:paragraph -->
+						<p>Published on</p>
+						<!-- /wp:paragraph -->
+						<!-- wp:post-date /-->
+					</div>
+					<!-- /wp:group -->
+				</div>
+				<!-- /wp:column -->
 
-<!-- wp:group {"className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide"><!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|50"}}}} -->
-<div class="wp-block-columns"><!-- wp:column {"width":"30%"} -->
-<div class="wp-block-column" style="flex-basis:30%"><!-- wp:group {"style":{"spacing":{"blockGap":"4px"}},"fontSize":"small","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group has-small-font-size"><!-- wp:paragraph -->
-<p>Published on</p>
-<!-- /wp:paragraph -->
+				<!-- wp:column {"width":"70%"} -->
+				<div class="wp-block-column" style="flex-basis:70%">
+					<!-- wp:post-content {"layout":{"type":"default"}} /-->
+				</div>
+				<!-- /wp:column -->
+			</div>
+			<!-- /wp:columns -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
 
-<!-- wp:post-date /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:column -->
+	<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:0">
+		<!-- wp:group {"tagName":"nav","align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|opacity-20","width":"1px"},"right":{},"bottom":{},"left":{}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+		<nav class="wp-block-group alignwide" aria-label="Post navigation" style="border-top-color:var(--wp--preset--color--opacity-20);border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
+			<!-- wp:post-navigation-link {"type":"previous","showTitle":true,"arrow":"arrow"} /-->
+			<!-- wp:post-navigation-link {"showTitle":true,"arrow":"arrow"} /-->
+		</nav>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|50"}}}} -->
+		<div class="wp-block-columns alignwide">
+			<!-- wp:column {"width":"30%"} -->
+			<div class="wp-block-column" style="flex-basis:30%">
+				<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
+				<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
+			</div>
+			<!-- /wp:column -->
+			<!-- wp:column {"width":"70%","style":{"spacing":{"padding":{"top":"0","bottom":"0"}}}} -->
+			<div class="wp-block-column" style="padding-top:0;padding-bottom:0;flex-basis:70%">
+				<!-- wp:comments {"className":"wp-block-comments-query-loop","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}}} -->
+				<div class="wp-block-comments wp-block-comments-query-loop" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
+					<!-- wp:heading {"fontSize":"x-large"} -->
+					<h2 class="wp-block-heading has-x-large-font-size">Comments</h2>
+					<!-- /wp:heading -->
+					<!-- wp:comments-title {"level":3,"fontSize":"large"} /-->
+					<!-- wp:comment-template -->
+						<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
+						<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">
+							<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
+							<div class="wp-block-group">
+								<!-- wp:avatar {"size":50} /-->
+								<!-- wp:group -->
+								<div class="wp-block-group">
+									<!-- wp:comment-date /-->
+									<!-- wp:comment-author-name /-->
+									<!-- wp:comment-content /-->
+									<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+									<div class="wp-block-group">
+										<!-- wp:comment-edit-link /-->
+										<!-- wp:comment-reply-link /-->
+									</div>
+									<!-- /wp:group -->
+								</div>
+								<!-- /wp:group -->
+							</div>
+							<!-- /wp:group -->
+						</div>
+						<!-- /wp:group -->
+					<!-- /wp:comment-template -->
 
-<!-- wp:column {"width":"70%"} -->
-<div class="wp-block-column" style="flex-basis:70%"><!-- wp:post-content {"layout":{"type":"default"}} /--></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
+					<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<!-- wp:comments-pagination-previous /-->
+					<!-- wp:comments-pagination-next /-->
+					<!-- /wp:comments-pagination -->
 
-<!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:0"><!-- wp:group {"tagName":"nav","align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|opacity-20","width":"1px"},"right":{},"bottom":{},"left":{}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<nav class="wp-block-group alignwide" aria-label="Post navigation" style="border-top-color:var(--wp--preset--color--opacity-20);border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:post-navigation-link {"type":"previous","showTitle":true,"arrow":"arrow"} /-->
-
-<!-- wp:post-navigation-link {"showTitle":true,"arrow":"arrow"} /--></nav>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|50"}}}} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"width":"30%"} -->
-<div class="wp-block-column" style="flex-basis:30%"><!-- wp:spacer {"height":"var:preset|spacing|20"} -->
-<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"width":"70%","style":{"spacing":{"padding":{"top":"0","bottom":"0"}}}} -->
-<div class="wp-block-column" style="padding-top:0;padding-bottom:0;flex-basis:70%"><!-- wp:comments {"className":"wp-block-comments-query-loop","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}}} -->
-<div class="wp-block-comments wp-block-comments-query-loop" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)"><!-- wp:heading {"fontSize":"x-large"} -->
-<h2 class="wp-block-heading has-x-large-font-size">Comments</h2>
-<!-- /wp:heading -->
-
-<!-- wp:comments-title {"level":3,"fontSize":"large"} /-->
-
-<!-- wp:comment-template -->
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
-<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
-<div class="wp-block-group"><!-- wp:avatar {"size":50} /-->
-
-<!-- wp:group -->
-<div class="wp-block-group"><!-- wp:comment-date /-->
-
-<!-- wp:comment-author-name /-->
-
-<!-- wp:comment-content /-->
-
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:comment-edit-link /-->
-
-<!-- wp:comment-reply-link /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-<!-- /wp:comment-template -->
-
-<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<!-- wp:comments-pagination-previous /-->
-
-<!-- wp:comments-pagination-next /-->
-<!-- /wp:comments-pagination -->
-
-<!-- wp:post-comments-form /--></div>
-<!-- /wp:comments --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
-<!-- /wp:group --></div>
+					<!-- wp:post-comments-form /-->
+				</div>
+				<!-- /wp:comments -->
+			</div>
+			<!-- /wp:column -->
+		</div>
+		<!-- /wp:columns -->
+	</div>
+	<!-- /wp:group -->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/patterns/offset-post-no-featured-image-template.php
+++ b/patterns/offset-post-no-featured-image-template.php
@@ -14,8 +14,8 @@
 ?>
 <!-- wp:template-part {"slug":"header","area":"header"} /-->
 
-<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide">
+<!-- wp:group {"tagName":"main","align":"wide","layout":{"type":"default"}} -->
+<main class="wp-block-group alignwide">
 	<!-- wp:group {"className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|40"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--40)">
 		<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}},"border":{"bottom":{"color":"var:preset|color|opacity-20","width":"1px"},"top":[],"right":[],"left":[]}},"layout":{"type":"default"}} -->
@@ -126,7 +126,7 @@
 		<!-- /wp:columns -->
 	</div>
 	<!-- /wp:group -->
-</div>
+</main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/patterns/template-single-offset.php
+++ b/patterns/template-single-offset.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: Offset post without featured image
- * Slug: twentytwentyfive/offset-post-no-featured-image-template
+ * Slug: twentytwentyfive/template-single-offset
  * Template Types: posts, single
  * Viewport width: 1400
  * Inserter: no
@@ -16,8 +16,8 @@
 
 <!-- wp:group {"tagName":"main","align":"wide","layout":{"type":"default"}} -->
 <main class="wp-block-group alignwide">
-	<!-- wp:group {"className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|40"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--40)">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|40"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--40)">
 		<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}},"border":{"bottom":{"color":"var:preset|color|opacity-20","width":"1px"},"top":[],"right":[],"left":[]}},"layout":{"type":"default"}} -->
 		<div class="wp-block-group alignwide" style="border-bottom-color:var(--wp--preset--color--opacity-20);border-bottom-width:1px;padding-bottom:var(--wp--preset--spacing--50)">
 			<!-- wp:post-title {"level":1,"align":"wide","fontSize":"xx-large"} /-->
@@ -27,8 +27,8 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:group {"className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group is-style-default" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--50)">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--50)">
 		<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
 		<div class="wp-block-group alignwide">
 			<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|50"}}}} -->
@@ -68,6 +68,7 @@
 		<!-- /wp:group -->
 	</div>
 	<!-- /wp:group -->
+
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
 		<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|50"}}}} -->
@@ -81,45 +82,7 @@
 			<!-- /wp:column -->
 			<!-- wp:column {"width":"70%","style":{"spacing":{"padding":{"top":"0","bottom":"0"}}}} -->
 			<div class="wp-block-column" style="padding-top:0;padding-bottom:0;flex-basis:70%">
-				<!-- wp:comments {"className":"wp-block-comments-query-loop","style":{"spacing":{"margin":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}}} -->
-				<div class="wp-block-comments wp-block-comments-query-loop" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
-					<!-- wp:heading {"fontSize":"x-large"} -->
-					<h2 class="wp-block-heading has-x-large-font-size">Comments</h2>
-					<!-- /wp:heading -->
-					<!-- wp:comments-title {"level":3,"fontSize":"large"} /-->
-					<!-- wp:comment-template -->
-						<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
-						<div class="wp-block-group" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)">
-							<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
-							<div class="wp-block-group">
-								<!-- wp:avatar {"size":50} /-->
-								<!-- wp:group -->
-								<div class="wp-block-group">
-									<!-- wp:comment-date /-->
-									<!-- wp:comment-author-name /-->
-									<!-- wp:comment-content /-->
-									<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-									<div class="wp-block-group">
-										<!-- wp:comment-edit-link /-->
-										<!-- wp:comment-reply-link /-->
-									</div>
-									<!-- /wp:group -->
-								</div>
-								<!-- /wp:group -->
-							</div>
-							<!-- /wp:group -->
-						</div>
-						<!-- /wp:group -->
-					<!-- /wp:comment-template -->
-
-					<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<!-- wp:comments-pagination-previous /-->
-					<!-- wp:comments-pagination-next /-->
-					<!-- /wp:comments-pagination -->
-
-					<!-- wp:post-comments-form /-->
-				</div>
-				<!-- /wp:comments -->
+				<!-- wp:pattern {"slug":"twentytwentyfive/comments"} /-->
 			</div>
 			<!-- /wp:column -->
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Adds the `<main>` HTML tag to the pattern. All templates must include a main, both because all content needs to be inside a landmark, but also because in block themes, the automated skip link requires it.

Indent the blocks in the file to improve the readability of the code.

Partial for https://github.com/WordPress/twentytwentyfive/issues/278

**Screenshots**



**Testing Instructions**

Apply the PR and go to Appearance > Editor > Templates.
Select the single post template.
In the settings sidebar, open the Template tab.
Open the Design panel and select the "Offset post without featured image" design.
Open the list view.
Select the group block that is between the header and footer.
In the block settings sidebar, open the Advanced panel.
Confirm that main is selected in the HTML element option.
Save.
View a single post on the front.
Confirm that there are no issues with the layout, the template should look identical before and after adding the main.
