### PR TITLE
Text-only single post: Move the category below the title

### DIFF
--- a/patterns/text-only-blog-single-post-template.php
+++ b/patterns/text-only-blog-single-post-template.php
@@ -18,9 +18,11 @@
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
 	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+		<!-- wp:post-title {"level":1,"fontSize":"xx-large"} /-->
 		<!-- wp:post-terms {"term":"category","style":{"typography":{"fontStyle":"normal","fontWeight":"400"}}} /-->
-		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"fontSize":"xx-large"} /-->
-
+		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+		<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
 		<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
 
 		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->

--- a/patterns/text-only-blog-single-post-template.php
+++ b/patterns/text-only-blog-single-post-template.php
@@ -18,7 +18,7 @@
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
 	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
-		<!-- wp:post-title {"level":1,"fontSize":"xx-large"} /-->
+		<!-- wp:post-title {"level":1} /-->
 		<!-- wp:post-terms {"term":"category","style":{"typography":{"fontStyle":"normal","fontWeight":"400"}}} /-->
 		<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
 		<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This PR adjusts the single post pattern for the text-only blog.
It moves the category below the post title and closes https://github.com/WordPress/twentytwentyfive/issues/293.
The reason for this is that displaying the category above the main heading is less accessible than displaying it below.

Changes made:
- I moved the post terms block below the post title.
- I removed the `preset-50` bottom margin on the post title so that the category could be displayed closer to the title.
- I added a `preset-50` spacer block between the post terms and the post content.

There is one inconsistency compared to the proposed design: the categories are not underlined by default.
This is because the post-terms block has the underline hidden by default, and showing on `:hover.`

**Testing Instructions**

Please see the new design in the linked issue, then enable the text-only design for the single post and confirm if the two results match:

Apply the PR.
Go to Appearance > Editor
Select Templates.
Open the Single post template
In the settings sidebar, open the Template tab.
Open the Design panel
Select the "Text-only blog, single post" pattern.

**Screenshot**
The text-only single post, on the front:

<img width="655" alt="A single post with the text-only template, showing the category below the title, and the tags below the content." src="https://github.com/user-attachments/assets/0b671bee-910d-4456-b281-9874e95dff6d">

