### PR TITLE
Vertical header, right aligned blog: Adjusts excerpt length and post title size

### DIFF
--- a/patterns/vertical-header-right-aligned-posts.php
+++ b/patterns/vertical-header-right-aligned-posts.php
@@ -17,14 +17,22 @@
 	<!-- wp:post-template -->
 		<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 		<div class="wp-block-group">
-			<!-- wp:post-title {"isLink":true} /-->
+			<!-- wp:post-title {"isLink":true,"fontSize":"xx-large"} /-->
 			<!-- wp:post-date {"fontSize":"small"} /-->
 		</div>
 		<!-- /wp:group -->
 		<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
 		<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		<!-- wp:post-excerpt {"moreText":""} /-->
+		<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|50"}}}} -->
+		<div class="wp-block-columns"><!-- wp:column {"width":"70%"} -->
+		<div class="wp-block-column" style="flex-basis:70%"><!-- wp:post-excerpt {"moreText":"","showMoreOnNewLine":false} /--></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column"></div>
+		<!-- /wp:column --></div>
+		<!-- /wp:columns -->
 		<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"16/9"} /-->
 		<!-- wp:spacer {"height":"var:preset|spacing|80"} -->
 		<div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>


### PR DESCRIPTION
**Description**

Adjusts the excerpt length (too long in big screens mentioned in #294) and also the post title size, intended to be larger than what it currently is.

**Screenshots**

On a 2500px screen:

https://github.com/user-attachments/assets/3248dcf7-469f-4c5b-9b2e-c47abc1e4152

