### PR TITLE
Remove the default palette, gradient and duotone

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -4,6 +4,9 @@
 	"settings": {
 		"appearanceTools": true,
 		"color": {
+			"defaultDuotone": false,
+			"defaultGradients": false,
+			"defaultPalette": false,
 			"palette": [
 				{
 					"color": "#FFFFFF",


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Sets the default color palette, gradients and duotones to false in theme.json, so that they do not distract from the theme colors.
Closes https://github.com/WordPress/twentytwentyfive/issues/308

**Testing Instructions**
Insert a block that has color options. Open the color options and confirm that the default palette and gradients are not available.
Insert and image block. In the block toolbar, select the duotone option. Confirm that the default duotones are not available.