### PR TITLE
Fine tune all search blocks

### DIFF
--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -35,7 +35,7 @@
 				<!-- wp:paragraph -->
 				<p><?php echo esc_html_x( 'The page you are looking for doesn\'t exist, or it has been moved. Please try searching using the form below.', '404 error message', 'twentytwentyfive' ); ?></p>
 				<!-- /wp:paragraph -->
-				<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'twentytwentyfive' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Type something...', 'input placeholder text', 'twentytwentyfive' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'button label', 'twentytwentyfive' ); ?>","style":{"border":{"radius":"999px"}}} /-->
+				<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'twentytwentyfive' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Type something...', 'input placeholder text', 'twentytwentyfive' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'button label', 'twentytwentyfive' ); ?>"} /-->
 			</div>
 			<!-- /wp:group -->
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
In this PR I am making small adjustments to the search block, to remove duplicate styles.
Closes https://github.com/WordPress/twentytwentyfive/issues/184

404: The border radius on the search block is not needed in the pattern, because it is already added in theme.json.


**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**
View the different patterns listed above, and confirm that the block looks the same as before the PR.