### PR TITLE
Add: theme utils to escape patterns.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/stylelint-config": "^22.5.0",
+				"fs-extra": "^11.1.0",
+				"parse5-html-rewriting-stream": "^7.0.0",
 				"stylelint": "^14.16.1"
 			},
 			"engines": {
@@ -458,6 +460,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
 		"node_modules/error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -591,6 +605,20 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/fs-extra": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+			"integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -698,6 +726,12 @@
 			"integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true
 		},
 		"node_modules/hard-rejection": {
 			"version": "2.1.0",
@@ -971,6 +1005,18 @@
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"dev": true,
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
@@ -1283,6 +1329,44 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+			"dev": true,
+			"dependencies": {
+				"entities": "^4.4.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5-html-rewriting-stream": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/parse5-html-rewriting-stream/-/parse5-html-rewriting-stream-7.0.0.tgz",
+			"integrity": "sha512-mazCyGWkmCRWDI15Zp+UiCqMp/0dgEmkZRvhlsqqKYr4SsVm/TvnSpD9fCvqCA2zoWJcfRym846ejWBBHRiYEg==",
+			"dev": true,
+			"dependencies": {
+				"entities": "^4.3.0",
+				"parse5": "^7.0.0",
+				"parse5-sax-parser": "^7.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5-sax-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/parse5-sax-parser/-/parse5-sax-parser-7.0.0.tgz",
+			"integrity": "sha512-5A+v2SNsq8T6/mG3ahcz8ZtQ0OUFTatxPbeidoMB7tkJSGDY3tdfl4MHovtLQHkEn5CGxijNWRQHhRQ6IRpXKg==",
+			"dev": true,
+			"dependencies": {
+				"parse5": "^7.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/path-exists": {
@@ -2065,6 +2149,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -23,12 +23,15 @@
 	},
 	"devDependencies": {
 		"@wordpress/stylelint-config": "^22.5.0",
-		"stylelint": "^14.16.1"
+		"stylelint": "^14.16.1",
+		"fs-extra": "^11.1.0",
+		"parse5-html-rewriting-stream": "^7.0.0"
 	},
 	"scripts": {
 		"lint:css": "stylelint **/*.css -i .gitignore",
 		"lint:css:fix": "stylelint **/*.css -i .gitignore --fix",
 		"lint:php": "composer run-script lint",
-		"lint:php:fix": "composer run-script format"
+		"lint:php:fix": "composer run-script format",
+		"patterns:escape": "node ./theme-utils.mjs escape-patterns"
 	}
 }

--- a/theme-utils.mjs
+++ b/theme-utils.mjs
@@ -1,0 +1,212 @@
+
+import { spawn } from 'child_process';
+import fs from 'fs';
+import { RewritingStream } from 'parse5-html-rewriting-stream';
+
+const isWin = process.platform === 'win32';
+
+const commands = {
+	"escape-patterns": {
+		helpText: 'Escapes block patterns for pattern files that have changes (staged or unstaged).',
+		run: () => escapePatterns()
+	},
+	"help": {
+		helpText: 'Displays the main help message.',
+		run: (args) => showHelp(args?.[1])
+	},
+};
+
+(async function start() {
+	let args = process.argv.slice(2);
+	let command = args?.[0];
+
+	if (!commands[command]) {
+		return showHelp();
+	}
+
+	commands[command].run(args);
+})();
+
+function showHelp(command = '') {
+	if (!command || !commands.hasOwnProperty(command)) {
+		console.log(`
+node theme-utils.mjs [command]
+
+Available commands:
+_(theme-utils.mjs help [command] for more details)_
+
+\t${Object.keys(commands).join('\n\t')}
+	`);
+		return;
+	}
+
+	const { helpText, additionalArgs } = commands[command];
+	console.log(`
+${command} ${additionalArgs ?? ''}
+
+${helpText}
+	`);
+}
+
+/*
+ Execute a command locally.
+*/
+export async function executeCommand(command, logResponse) {
+	const timeout = 2*60*1000; // 2 min
+
+	return new Promise((resolove, reject) => {
+		let child;
+		let response = '';
+		let errResponse = '';
+
+		if (isWin) {
+			child = spawn('cmd.exe', ['/s', '/c', '"' + command + '"'], {
+				windowsVerbatimArguments: true,
+				stdio: [process.stdin, 'pipe', 'pipe'],
+				detached: true,
+			})
+		} else {
+			child = spawn(process.env.SHELL, ['-c', command], {
+				stdio: [process.stdin, 'pipe', 'pipe'],
+				detached: true,
+			});
+		}
+
+		var timer = setTimeout(() => {
+			try {
+				process.kill(-child.pid, 'SIGKILL');
+			} catch (e) {
+				console.log('Cannot kill process');
+			}
+		}, timeout);
+
+		child.stdout.on('data', (data) => {
+			response += data;
+			if (logResponse) {
+				console.log(data.toString());
+			}
+		});
+
+		child.stderr.on('data', (data) => {
+			errResponse += data;
+			if (logResponse) {
+				console.log(data.toString());
+			}
+		});
+
+		child.on('exit', (code) => {
+			clearTimeout(timer)
+			if (code !== 0) {
+				reject(errResponse.trim());
+			}
+			resolove(response.trim());
+		});
+	});
+}
+
+async function escapePatterns() {
+	// get staged files
+	const staged = (await executeCommand(`git diff --cached --name-only`)).split('\n');
+	// get unstaged, untracked files
+	const unstaged = (await executeCommand(`git ls-files -m -o --exclude-standard`)).split('\n');
+
+	// avoid duplicates and filter pattern files
+	const patterns = [...new Set([...staged, ...unstaged])].filter(file => file.match(/patterns\/.*.php/g));
+
+	patterns.forEach(file => {
+		const rewriter = getReWriter('twentytwentyfive');
+		const tmpFile = `${file}-tmp`;
+		const readStream = fs.createReadStream( file, { encoding: 'UTF-8' } );
+		const writeStream = fs.createWriteStream( tmpFile, { encoding: 'UTF-8' } );
+		writeStream.on('finish', () => {
+			fs.renameSync(tmpFile, file);
+		});
+
+		readStream.pipe(rewriter).pipe(writeStream);
+	});
+
+	// Helper functions
+	function getReWriter(themeSlug) {
+		const rewriter = new RewritingStream();
+
+		rewriter.on('text', (_, raw) => {
+			rewriter.emitRaw(escapeText(raw, themeSlug));
+		});
+
+		rewriter.on('startTag', (startTag, rawHtml) => {
+			if (startTag.tagName === 'img') {
+				const attrs = startTag.attrs.filter(attr => ['src', 'alt'].includes(attr.name));
+				attrs.forEach(attr => {
+					if (attr.name === 'src') {
+						attr.value = escapeImagePath(attr.value);
+					} else if (attr.name === 'alt') {
+						attr.value = escapeText(attr.value, themeSlug, true);
+					}
+				});
+			}
+
+
+			rewriter.emitStartTag(startTag);
+		});
+
+		rewriter.on('comment', (comment, rawHtml) => {
+			if (comment.text.startsWith('?php')) {
+				rewriter.emitRaw(rawHtml);
+				return;
+			}
+			// escape the strings in block config (blocks that are represented as comments)
+			// ex: <!-- wp:search {label: "Search"} /-->
+			const block = escapeBlockAttrs(comment.text, themeSlug)
+			rewriter.emitComment({...comment, text: block})
+		});
+
+		return rewriter;
+	}
+
+	function escapeBlockAttrs(block, themeSlug) {
+		// Set isAttr to true if it is an attribute in the result HTML
+		// If set to true, it generates esc_attr_, otherwise it generates esc_html_
+		const allowedAttrs=[
+			{ name: 'label' },
+			{ name: 'placeholder', isAttr: true },
+			{ name: 'buttonText' },
+			{ name: 'content' }
+		];
+		const start = block.indexOf('{');
+		const end = block.lastIndexOf('}');
+
+		const configPrefix = block.slice(0, start);
+		const config = block.slice(start, end+1);
+		const configSuffix = block.slice(end+1);
+
+		try {
+			const configJson = JSON.parse(config);
+			allowedAttrs.forEach((attr) => {
+				if (!configJson[attr.name]) return;
+				configJson[attr.name] = escapeText(configJson[attr.name], themeSlug, attr.isAttr)
+			})
+			return configPrefix + JSON.stringify(configJson) + configSuffix;
+		} catch (error) {
+			// do nothing
+			return block
+		}
+	}
+
+	function escapeText(text, themeSlug, isAttr = false) {
+		const trimmedText = text && text.trim();
+		if (!themeSlug || !trimmedText || trimmedText.startsWith(`<?php`)) return text;
+		const escFunction = isAttr ? 'esc_attr__' : 'esc_html__';
+		const spaceChar = text.startsWith(' ') ? '&nbsp;' : ''
+		const resultText = text.replace('\'', '\\\'').trim();
+		return `${spaceChar}<?php echo ${escFunction}( '${resultText}', '${themeSlug}' ); ?>`;
+	}
+
+	function escapeImagePath(src) {
+		if (!src || src.trim().startsWith('<?php')) return src;
+
+		const assetsDir = 'assets';
+		const parts = src.split('/');
+		const resultSrc = parts.slice(parts.indexOf(assetsDir)).join('/');
+		return `<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/${resultSrc}`;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Adding theme utils to escape patterns via command. It uses a variation of the `theme-utils` from community themes, with some hardcoded pieces to work with TT5. This iteration only includes the command to escape patterns and not the json schema validator.

To try it out, first, you need to install it.

```
nvm use && npm install
```

Once installed, you can try it out using the following command. It only works on the files that are modified in your local git.

```
npm run patterns:escape
```

It'll be a good tool to speed up escaping the different patterns we have already merged. We should have probably looked into this before, but it's better now than never.

**Screenshots**

https://github.com/user-attachments/assets/a9534047-ad67-4ef5-9f8c-912d791f08fd

**Testing Instructions**

See description.
