### PR TITLE
Fix: Add description to landing pages.

### DIFF
--- a/patterns/page-landing-event.php
+++ b/patterns/page-landing-event.php
@@ -7,7 +7,7 @@
  * Block Types: core/post-content
  * Post Types: page, wp_template
  * Viewport width: 1400
- * Description: .
+ * Description: A landing page for the event with a hero section, description, FAQs and call to action.
  *
  * @package WordPress
  * @subpackage Twenty_Twenty_Five

--- a/patterns/page-landing-podcast.php
+++ b/patterns/page-landing-podcast.php
@@ -7,7 +7,7 @@
  * Block Types: core/post-content
  * Post Types: page, wp_template
  * Viewport width: 1400
- * Description: .
+ * Description: A landing page for the podcast with a hero section, description, clients, grid with videos and newsletter signup.
  *
  * @package WordPress
  * @subpackage Twenty_Twenty_Five


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Adding description to landing pages.

**Screenshots**

N/A

**Testing Instructions**

1. Open the files.
2. Confirm that the description is in place.
