### PR TITLE
Removes 'more posts' from home and index templates

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -4,7 +4,6 @@
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
 	<!-- wp:pattern {"slug":"twentytwentyfive/hidden-blog-heading"} /-->
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->
-	<!-- wp:pattern {"slug":"twentytwentyfive/more-posts"} /-->
 </main>
 <!-- /wp:group -->
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,6 @@
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
 	<!-- wp:pattern {"slug":"twentytwentyfive/hidden-blog-heading"} /-->
 	<!-- wp:pattern {"slug":"twentytwentyfive/posts-personal-blog"} /-->
-	<!-- wp:pattern {"slug":"twentytwentyfive/more-posts"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

<!-- Describe the purpose or reason for the pull request -->
The Home and Index templates on twentytwentyfive have a section(pattern) that lists 'More Posts'. This is unnecessary and shows the first posts on all pages when using pagination. One the first page this is also redundant. 
#326 