### PR TITLE
Add theme preview with WordPress Playground

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,25 @@
+name: Preview Theme Changes
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+permissions:
+  pull-requests: write
+
+
+jobs:
+  preview-theme-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Preview Theme Changes
+        uses: vcanales/action-wp-playground-pr-preview@trunk
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          base-branch: trunk
+          single-theme: true

--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -44,4 +44,3 @@
 	<!-- /wp:columns -->
 </div>
 <!-- /wp:group -->
-<?php echo 'Test Change'; ?>

--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -44,3 +44,4 @@
 	<!-- /wp:columns -->
 </div>
 <!-- /wp:group -->
+<?php echo 'Test Change'; ?>


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

I've recently updated the GitHub action that generates links to a Playground instance in order to preview the changes on a PR to [support single-theme repos](https://github.com/vcanales/action-wp-playground-pr-preview/pull/31), so that we may use it in repos like this one.

It still requires a lot polish, but after merging, we should be seeing messages such as the ones displayed in this PR from a fork I used for testing:

https://github.com/vcanales/twentytwentyfive/pull/2
