### PR TITLE
Separator: Set a max width on the wide style variation

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1303,6 +1303,11 @@
 				},
 				"color": {
 					"text": "var:preset|color|opacity-20"
+				},
+				"variations": {
+					"wide": {
+						"css": " &:not(.alignfull){max-width: 1340px;}"
+					}
 				}
 			},
 			"core/site-tagline": {

--- a/theme.json
+++ b/theme.json
@@ -1306,7 +1306,7 @@
 				},
 				"variations": {
 					"wide": {
-						"css": " &:not(.alignfull){max-width: var(--wp--style--global--wide-size);}"
+						"css": " &:not(.alignfull){max-width: var(--wp--style--global--wide-size) !important;}"
 					}
 				}
 			},

--- a/theme.json
+++ b/theme.json
@@ -1306,7 +1306,7 @@
 				},
 				"variations": {
 					"wide": {
-						"css": " &:not(.alignfull){max-width: 1340px;}"
+						"css": " &:not(.alignfull){max-width: var(--wp--style--global--wide-size);}"
 					}
 				}
 			},


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
When a block theme does not add theme support for the legacy block styles, 
the default separator and the wide style variation for the separator are identical.

This pr uses custom CSS in theme.json to set the wide style variation to a max width that matches the wide content width.
It also respects the full width alignment, if a user chooses the wide style but then changes it to full width in the block toolbar.

This PR replaces 
https://github.com/WordPress/twentytwentyfive/pull/255

**Testing Instructions**
Add a default separator, a separator with the wide style, and a full width separator and compare the widths in the editor and front.

You can use this sample code:
```
<!-- wp:paragraph -->
<p>Default</p>
<!-- /wp:paragraph -->

<!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator -->

<!-- wp:paragraph -->
<p>Wide style variation</p>
<!-- /wp:paragraph -->

<!-- wp:separator {"className":"is-style-wide"} -->
<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
<!-- /wp:separator -->

<!-- wp:paragraph -->
<p>Wide style variation, with <strong>wide </strong>width set in the block toolbar</p>
<!-- /wp:paragraph -->

<!-- wp:separator {"align":"wide","className":"is-style-wide"} -->
<hr class="wp-block-separator alignwide has-alpha-channel-opacity is-style-wide"/>
<!-- /wp:separator -->

<!-- wp:paragraph -->
<p>Wide style variation, with <strong>full </strong>width set in the block toolbar</p>
<!-- /wp:paragraph -->

<!-- wp:separator {"align":"full","className":"is-style-wide"} -->
<hr class="wp-block-separator alignfull has-alpha-channel-opacity is-style-wide"/>
<!-- /wp:separator -->

<!-- wp:paragraph -->
<p>Default variation, with full width set in the block toolbar</p>
<!-- /wp:paragraph -->

<!-- wp:separator {"align":"full","className":"is-style-default"} -->
<hr class="wp-block-separator alignfull has-alpha-channel-opacity is-style-default"/>
<!-- /wp:separator -->

```
----
These are the props from the previous PR:
```
If you're merging code through a pull request on GitHub, copy and paste the following into the bottom of the merge commit message.

Co-authored-by: shail-mehta <shailu25@git.wordpress.org>
Co-authored-by: rejaulalomkhan <rejaulalomkhan@git.wordpress.org>
Co-authored-by: carolinan <poena@git.wordpress.org>
Co-authored-by: beafialho <beafialho@git.wordpress.org>
```

**Screenshots**
Editor:
![image](https://github.com/user-attachments/assets/4ca26327-7358-498c-8952-f48a633b3c7f)
