### PR TITLE
Fix featured images mobile

### DIFF
--- a/patterns/posts-personal-blog.php
+++ b/patterns/posts-personal-blog.php
@@ -12,8 +12,8 @@
  */
 
 ?>
-<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"align":"full","layout":{"type":"default"}} -->
-<div class="wp-block-query alignfull">
+<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"layout":{"type":"default"}} -->
+<div class="wp-block-query">
 	<!-- wp:group {"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
 		<!-- wp:query-no-results -->
@@ -22,11 +22,11 @@
 	</div>
 	<!-- /wp:group -->
 	<!-- wp:post-template {"align":"full","layout":{"type":"default"}} -->
-		<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+		<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"default"}} -->
 		<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 			<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
 			<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
-			<!-- wp:post-content {"align":"full","fontSize":"medium","layout":{"type":"constrained"}} /-->
+			<!-- wp:post-content {"align":"full","fontSize":"medium","layout":{"type":"default"}} /-->
 			<!-- wp:post-date {"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}},"fontSize":"small"} /-->
 		</div>
 		<!-- /wp:group -->


### PR DESCRIPTION

**Description**

This PR fixes issue #345 
To solve it the constrained layout setting has been removed from the query loop, the group inside and the post content block

**Screenshots**

![Screenshot from 2024-09-18 11-29-42](https://github.com/user-attachments/assets/7a391ee8-04c1-4e43-a5f3-c1273aabc5e5)
![Screenshot from 2024-09-18 11-29-15](https://github.com/user-attachments/assets/b328846a-cc75-4c88-9a0e-a26ec60887eb)
![Screenshot from 2024-09-18 11-28-43](https://github.com/user-attachments/assets/c3193794-ea5d-49ac-a0a3-2c9a4f0d9f60)


**Testing Instructions**

Got to all the templates that use the posts-personal-blog pattern, that is home index search and archive from the editor, switch to mobile view and verify the featured image has the right horizontal paddings. Then visit the web from the browser to make sure nothing has changed.