### PR TITLE
Fix: Fine tune search block, and use it in different search results templates.

### DIFF
--- a/patterns/hidden-404.php
+++ b/patterns/hidden-404.php
@@ -35,7 +35,7 @@
 				<!-- wp:paragraph -->
 				<p><?php echo esc_html_x( 'The page you are looking for doesn\'t exist, or it has been moved. Please try searching using the form below.', '404 error message', 'twentytwentyfive' ); ?></p>
 				<!-- /wp:paragraph -->
-				<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'twentytwentyfive' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Type something...', 'input placeholder text', 'twentytwentyfive' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'button label', 'twentytwentyfive' ); ?>","style":{"border":{"radius":"999px"}}} /-->
+				<!-- wp:pattern {"slug":"twentytwentyfive/hidden-search"} /-->
 			</div>
 			<!-- /wp:group -->
 		</div>

--- a/patterns/hidden-search.php
+++ b/patterns/hidden-search.php
@@ -11,4 +11,4 @@
 
 ?>
 
-<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'twentytwentyfive' ); ?>","showLabel":false,"buttonText":"<?php echo esc_attr_x( 'Search', 'button label', 'twentytwentyfive' ); ?>","style":{"border":{"radius":"50px"}},"fontSize":"medium","borderColor":"opacity-20"} /-->
+<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'twentytwentyfive' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Type something...', 'input placeholder text', 'twentytwentyfive' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'button label', 'twentytwentyfive' ); ?>","style":{"border":{"radius":"999px"}},"fontSize":"medium","borderColor":"opacity-20"} /-->

--- a/patterns/hidden-search.php
+++ b/patterns/hidden-search.php
@@ -11,4 +11,4 @@
 
 ?>
 
-<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'twentytwentyfive' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Type something...', 'input placeholder text', 'twentytwentyfive' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'button label', 'twentytwentyfive' ); ?>","style":{"border":{"radius":"999px"}},"fontSize":"medium","borderColor":"opacity-20"} /-->
+<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'twentytwentyfive' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Type something...', 'input placeholder text', 'twentytwentyfive' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'button label', 'twentytwentyfive' ); ?>","fontSize":"medium","borderColor":"opacity-20"} /-->

--- a/patterns/hidden-search.php
+++ b/patterns/hidden-search.php
@@ -11,4 +11,4 @@
 
 ?>
 
-<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'twentytwentyfive' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Type something...', 'input placeholder text', 'twentytwentyfive' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'button label', 'twentytwentyfive' ); ?>","fontSize":"medium","borderColor":"opacity-20"} /-->
+<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'twentytwentyfive' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Type something...', 'input placeholder text', 'twentytwentyfive' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'button label', 'twentytwentyfive' ); ?>"} /-->

--- a/patterns/news-blog-search-results-template.php
+++ b/patterns/news-blog-search-results-template.php
@@ -15,25 +15,33 @@
 <!-- wp:template-part {"slug":"header","area":"header"} /-->
 
 <!-- wp:group {"lock":{"move":false,"remove":false},"metadata":{"name":"Archive title and term description"},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide"><!-- wp:spacer {"height":"var:preset|spacing|80"} -->
-<div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
+<div class="wp-block-group">
+	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
+	<div class="wp-block-group alignwide">
+		<!-- wp:spacer {"height":"var:preset|spacing|80"} -->
+		<div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
 
-<!-- wp:query-title {"type":"search"} /-->
+		<!-- wp:query-title {"type":"search"} /-->
 
-<!-- wp:pattern {"slug":"twentytwentyfive/hidden-search"} /-->
+		<!-- wp:pattern {"slug":"twentytwentyfive/hidden-search"} /-->
 
-<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
-<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
-<!-- /wp:group --></div>
+		<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
+		<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
+	</div>
+	<!-- /wp:group -->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:group {"metadata":{"name":"Posts list"},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
-<div class="wp-block-group alignwide"><!-- wp:pattern {"slug":"twentytwentyfive/news-blog-query-loop"} /--></div>
-<!-- /wp:group --></div>
+<div class="wp-block-group">
+	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
+	<div class="wp-block-group alignwide">
+		<!-- wp:pattern {"slug":"twentytwentyfive/news-blog-query-loop"} /-->
+	</div>
+	<!-- /wp:group -->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer-newsletter","area":"footer"} /-->

--- a/patterns/news-blog-search-results-template.php
+++ b/patterns/news-blog-search-results-template.php
@@ -22,7 +22,7 @@
 
 <!-- wp:query-title {"type":"search"} /-->
 
-<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","style":{"border":{"radius":"50px"}},"fontSize":"medium","borderColor":"opacity-20"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfive/hidden-search"} /-->
 
 <!-- wp:spacer {"height":"var:preset|spacing|40"} -->
 <div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>

--- a/patterns/photo-blog-search-results-template.php
+++ b/patterns/photo-blog-search-results-template.php
@@ -19,7 +19,7 @@
 	<!-- wp:query-title {"type":"search","textAlign":"center","align":"wide"} /-->
 	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide">
-		<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","align":"center","style":{"border":{"radius":"50px"}},"fontSize":"medium"} /-->
+		<!-- wp:pattern {"slug":"twentytwentyfive/hidden-search"} /-->
 	</div>
 	<!-- /wp:group -->
 	<!-- wp:pattern {"slug":"twentytwentyfive/photo-blog-posts"} /-->

--- a/patterns/text-only-blog-search-template.php
+++ b/patterns/text-only-blog-search-template.php
@@ -19,7 +19,7 @@
 	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide">
 		<!-- wp:query-title {"type":"search","align":"wide","fontSize":"x-large"} /-->
-		<!-- wp:search {"label":"Search","showLabel":false,"widthUnit":"%","buttonText":"Search","style":{"border":{"radius":"100px"}},"fontSize":"small","borderColor":"opacity-20"} /-->
+		<!-- wp:pattern {"slug":"twentytwentyfive/hidden-search"} /-->
 	</div>
 	<!-- /wp:group -->
 	<!-- wp:spacer {"height":"var:preset|spacing|50"} -->

--- a/patterns/vertical-header-right-aligned-search-results-template.php
+++ b/patterns/vertical-header-right-aligned-search-results-template.php
@@ -41,7 +41,7 @@
 			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
 			<!-- /wp:spacer -->
 			<!-- wp:query-title {"type":"search","fontSize":"large"} /-->
-			<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","style":{"border":{"radius":"50px"}},"fontSize":"small","borderColor":"opacity-20"} /-->
+			<!-- wp:pattern {"slug":"twentytwentyfive/hidden-search"} /-->
 			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
 			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
 			<!-- /wp:spacer -->

--- a/theme.json
+++ b/theme.json
@@ -1277,7 +1277,7 @@
 				}
 			},
 			"core/search": {
-				"css": "& .wp-block-search__input{border-radius:3.125rem;padding-left:1.5625rem;padding-right:1.5625rem;}",
+				"css": "& .wp-block-search__input{border-radius:3.125rem;padding-left:1.5625rem;padding-right:1.5625rem;border-color:var(--wp--preset--color--opacity-20);}",
 				"typography": {
 					"fontSize": "var:preset|font-size|medium",
 					"lineHeight": "1.6"
@@ -1290,6 +1290,11 @@
 						"spacing": {
 							"margin": {
 								"left": "1.125rem"
+							}
+						},
+						":hover" : {
+							"border": {
+								"color": "transparent"
 							}
 						}
 					}
@@ -1393,7 +1398,7 @@
 						"text": "var:preset|color|contrast"
 					},
 					"border": {
-						"color": "var:preset|color|accent-1"
+						"color": "currentColor"
 					}
 				},
 				"border": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

<!-- Describe the purpose or reason for the pull request -->
Fixes https://github.com/WordPress/twentytwentyfive/issues/184

- Updating `hidden-search` pattern.
- Including the pattern in the different templates, as in Figma, they all use the same size.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

https://github.com/user-attachments/assets/0e644a00-486c-444a-850e-9da236f1d748


**Testing Instructions**

1. Go to the site editor.
2. Look for the search results template.
3. Try every one of them, and confirm that the search section looks like in Figma.
4. Go to `yoursite.local/404` (replace `yoursite.local` with the site you're trying) and confirm that it also looks well on the 404 page.
