### PR TITLE
Update Book and Podcast hero pattern from using h2 to h1

### DIFF
--- a/patterns/hero-book.php
+++ b/patterns/hero-book.php
@@ -36,8 +36,8 @@
 		<div class="wp-block-column is-vertically-aligned-center">
 			<!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|50"}},"layout":{"type":"constrained","contentSize":"515px","justifyContent":"left"}} -->
 			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
-				<!-- wp:heading {"fontSize":"xx-large"} -->
-				<h2 class="wp-block-heading has-xx-large-font-size"><?php echo esc_html_x( 'The Stories Book', 'Heading of the hero section', 'twentytwentyfive' ); ?></h2>
+				<!-- wp:heading {"level":1,"fontSize":"xx-large"} -->
+				<h1 class="wp-block-heading has-xx-large-font-size"><?php echo esc_html_x( 'The Stories Book', 'Heading of the hero section', 'twentytwentyfive' ); ?></h1>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"300"}},"fontSize":"large"} -->

--- a/patterns/hero-podcast.php
+++ b/patterns/hero-podcast.php
@@ -27,8 +27,8 @@
 
 		<!-- wp:column {"verticalAlignment":"center","width":"60%"} -->
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:60%">
-			<!-- wp:heading {"fontSize":"xx-large"} -->
-			<h2 class="wp-block-heading has-xx-large-font-size">The Stories Podcast</h2>
+			<!-- wp:heading {"level":1,"fontSize":"xx-large"} -->
+			<h1 class="wp-block-heading has-xx-large-font-size">The Stories Podcast</h1>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30"}}}} -->

--- a/patterns/hero-podcast.php
+++ b/patterns/hero-podcast.php
@@ -35,8 +35,8 @@
 			<p style="padding-top:var(--wp--preset--spacing--30)"><?php echo esc_html_x( 'Storytelling, expert analysis, and vivid descriptions. The Stories Podcast brings history to life, making it accessible and engaging for a global audience.', 'Podcast description', 'twentytwentyfive' ); ?></p>
 			<!-- /wp:paragraph -->
 
-			<!-- wp:heading {"level":3,"style":{"spacing":{"padding":{"top":"var:preset|spacing|30"}}},"fontSize":"large"} -->
-			<h3 class="wp-block-heading has-large-font-size" style="padding-top:var(--wp--preset--spacing--30)"><strong><?php echo esc_html_x( 'Subscribe on your favorite platform', 'Subscription heading', 'twentytwentyfive' ); ?></strong></h3>
+			<!-- wp:heading {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30"}}},"fontSize":"large"} -->
+			<h2 class="wp-block-heading has-large-font-size" style="padding-top:var(--wp--preset--spacing--30)"><strong>Subscribe on your favorite platform</strong></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

The Book and Podcast landing page patterns were both missing an h1. I've updated the hero patterns to use h1 instead of h2.

Fixes #369.

**Screenshots**

No visual change.

**Testing Instructions**

<!-- Provide steps for testing -->
1. Ensure the theme is active
2. Add a new page
3. Select the Book or Podcast landing page patterns
4. Ensure the hero pattern at the top is using an h1 instead of h2
