### PR TITLE
Remove trailing commas to ensure PHP 7.2 and below compatibility

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -41,7 +41,7 @@ if ( ! function_exists( 'twentytwentyfive_enqueue_styles' ) ) :
 			'twentytwentyfive-style',
 			get_parent_theme_file_uri( 'style.css' ),
 			array(),
-			wp_get_theme()->get( 'Version' ),
+			wp_get_theme()->get( 'Version' )
 		);
 	}
 endif;
@@ -170,7 +170,7 @@ if ( ! function_exists( 'twentytwentyfive_copyright_binding' ) ) :
 			/* translators: 1: Copyright symbol or word, 2: Year */
 			esc_html__( '%1$s %2$s', 'twentytwentyfive' ),
 			'&copy;',
-			wp_date( 'Y' ),
+			wp_date( 'Y' )
 		);
 
 		return $copyright_text;


### PR DESCRIPTION
**Description**

This update removes trailing commas in function calls within the theme functions file to ensure compatibility with PHP 7.2 and below. In PHP, trailing commas are not allowed in function calls before PHP 7.3, and the theme requirements specify PHP 7.2.24+ in
https://github.com/WordPress/twentytwentyfive?tab=readme-ov-file#requirements

Changes:
- Removed trailing comma from `wp_enqueue_style` function in the `twentytwentyfive_enqueue_styles` function.
- Removed trailing comma from `sprintf` function in the `twentytwentyfive_copyright_binding` function.

This fixes potential syntax errors for users running PHP 7.2 and earlier versions, ensuring compatibility across supported PHP versions.

**Testing Instructions**

1. Activate the theme.
2. Do a smoke test, it should work normally.
