### PR TITLE
Update: Try fixing the text wrapping of the site title

### DIFF
--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -18,52 +18,53 @@
 	<div class="wp-block-group alignwide">
 		<!-- wp:site-logo /-->
 
-		<!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"top"}} -->
-		<div class="wp-block-group alignfull">
-			<!-- wp:columns -->
-			<div class="wp-block-columns">
-				<!-- wp:column {"width":"100%"} -->
-				<div class="wp-block-column" style="flex-basis:100%"><!-- wp:site-title {"level":2} /-->
+		<!-- wp:columns -->
+		<div class="wp-block-columns">
+			<!-- wp:column {"width":"40%"} -->
+			<div class="wp-block-column" style="flex-basis:40%">
+				<!-- wp:site-title {"level":2} /-->
 
 				<!-- wp:site-tagline /-->
-				</div>
-				<!-- /wp:column -->
-
-				<!-- wp:column {"width":""} -->
-				<div class="wp-block-column">
-					<!-- wp:spacer {"height":"var:preset|spacing|40","width":"0px"} -->
-					<div style="height:var(--wp--preset--spacing--40);width:0px" aria-hidden="true" class="wp-block-spacer"></div>
-					<!-- /wp:spacer -->
-				</div>
-				<!-- /wp:column -->
 			</div>
-			<!-- /wp:columns -->
+			<!-- /wp:column -->
 
-			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|80"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"top","justifyContent":"space-between"}} -->
-			<div class="wp-block-group">
-				<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} -->
-					<!-- wp:navigation-link {"label":"Blog","url":"#"} /-->
-
-					<!-- wp:navigation-link {"label":"About","url":"#"} /-->
-
-					<!-- wp:navigation-link {"label":"FAQs","url":"#"} /-->
-
-					<!-- wp:navigation-link {"label":"Authors","url":"#"} /-->
-				<!-- /wp:navigation -->
-
-				<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} -->
-					<!-- wp:navigation-link {"label":"Events","url":"#"} /-->
-
-					<!-- wp:navigation-link {"label":"Shop","url":"#"} /-->
-
-					<!-- wp:navigation-link {"label":"Patterns","url":"#"} /-->
-
-					<!-- wp:navigation-link {"label":"Themes","url":"#"} /-->
-				<!-- /wp:navigation -->
+			<!-- wp:column {"width":"25%"} -->
+			<div class="wp-block-column" style="flex-basis:25%">
+				<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
+				<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
 			</div>
+			<!-- /wp:column -->
+
+			<!-- wp:column  -->
+			<div class="wp-block-column">
+				<!-- wp:group {"layout":{"type":"grid","columnCount":2}} -->
+				<div class="wp-block-group">
+					<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} -->
+						<!-- wp:navigation-link {"label":"Blog","url":"#"} /-->
+
+						<!-- wp:navigation-link {"label":"About","url":"#"} /-->
+
+						<!-- wp:navigation-link {"label":"FAQs","url":"#"} /-->
+
+						<!-- wp:navigation-link {"label":"Authors","url":"#"} /-->
+					<!-- /wp:navigation -->
+
+					<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} -->
+						<!-- wp:navigation-link {"label":"Events","url":"#"} /-->
+
+						<!-- wp:navigation-link {"label":"Shop","url":"#"} /-->
+
+						<!-- wp:navigation-link {"label":"Patterns","url":"#"} /-->
+
+						<!-- wp:navigation-link {"label":"Themes","url":"#"} /-->
+					<!-- /wp:navigation -->
+				</div>
 				<!-- /wp:group -->
+			</div>
+			<!-- /wp:column -->
 		</div>
-		<!-- /wp:group -->
+		<!-- /wp:columns -->
 
 		<!-- wp:spacer {"height":"var:preset|spacing|70"} -->
 		<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -18,53 +18,52 @@
 	<div class="wp-block-group alignwide">
 		<!-- wp:site-logo /-->
 
-		<!-- wp:columns -->
-		<div class="wp-block-columns">
-			<!-- wp:column {"width":"40%"} -->
-			<div class="wp-block-column" style="flex-basis:40%">
-				<!-- wp:site-title {"level":2} /-->
+		<!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between","verticalAlignment":"top"}} -->
+		<div class="wp-block-group alignfull">
+			<!-- wp:columns -->
+			<div class="wp-block-columns">
+				<!-- wp:column {"width":"100%"} -->
+				<div class="wp-block-column" style="flex-basis:100%"><!-- wp:site-title {"level":2} /-->
 
 				<!-- wp:site-tagline /-->
-			</div>
-			<!-- /wp:column -->
-
-			<!-- wp:column {"width":"25%"} -->
-			<div class="wp-block-column" style="flex-basis:25%">
-				<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
-				<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
-				<!-- /wp:spacer -->
-			</div>
-			<!-- /wp:column -->
-
-			<!-- wp:column  -->
-			<div class="wp-block-column">
-				<!-- wp:group {"layout":{"type":"grid","columnCount":2}} -->
-				<div class="wp-block-group">
-					<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} -->
-						<!-- wp:navigation-link {"label":"Blog","url":"#"} /-->
-
-						<!-- wp:navigation-link {"label":"About","url":"#"} /-->
-
-						<!-- wp:navigation-link {"label":"FAQs","url":"#"} /-->
-
-						<!-- wp:navigation-link {"label":"Authors","url":"#"} /-->
-					<!-- /wp:navigation -->
-
-					<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} -->
-						<!-- wp:navigation-link {"label":"Events","url":"#"} /-->
-
-						<!-- wp:navigation-link {"label":"Shop","url":"#"} /-->
-
-						<!-- wp:navigation-link {"label":"Patterns","url":"#"} /-->
-
-						<!-- wp:navigation-link {"label":"Themes","url":"#"} /-->
-					<!-- /wp:navigation -->
 				</div>
-				<!-- /wp:group -->
+				<!-- /wp:column -->
+
+				<!-- wp:column {"width":""} -->
+				<div class="wp-block-column">
+					<!-- wp:spacer {"height":"var:preset|spacing|40","width":"0px"} -->
+					<div style="height:var(--wp--preset--spacing--40);width:0px" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer -->
+				</div>
+				<!-- /wp:column -->
 			</div>
-			<!-- /wp:column -->
+			<!-- /wp:columns -->
+
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|80"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"top","justifyContent":"space-between"}} -->
+			<div class="wp-block-group">
+				<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} -->
+					<!-- wp:navigation-link {"label":"Blog","url":"#"} /-->
+
+					<!-- wp:navigation-link {"label":"About","url":"#"} /-->
+
+					<!-- wp:navigation-link {"label":"FAQs","url":"#"} /-->
+
+					<!-- wp:navigation-link {"label":"Authors","url":"#"} /-->
+				<!-- /wp:navigation -->
+
+				<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} -->
+					<!-- wp:navigation-link {"label":"Events","url":"#"} /-->
+
+					<!-- wp:navigation-link {"label":"Shop","url":"#"} /-->
+
+					<!-- wp:navigation-link {"label":"Patterns","url":"#"} /-->
+
+					<!-- wp:navigation-link {"label":"Themes","url":"#"} /-->
+				<!-- /wp:navigation -->
+			</div>
+				<!-- /wp:group -->
 		</div>
-		<!-- /wp:columns -->
+		<!-- /wp:group -->
 
 		<!-- wp:spacer {"height":"var:preset|spacing|70"} -->
 		<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -22,72 +22,72 @@
 		<div class="wp-block-group alignfull">
 			<!-- wp:columns -->
 			<div class="wp-block-columns">
-				<!-- wp:column {"width":"66.66%"} -->
-				<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:site-title {"level":2} /-->
+				<!-- wp:column {"width":"100%"} -->
+				<div class="wp-block-column" style="flex-basis:100%"><!-- wp:site-title {"level":2} /-->
 
 				<!-- wp:site-tagline /-->
+				</div>
+				<!-- /wp:column -->
+
+				<!-- wp:column {"width":""} -->
+				<div class="wp-block-column">
+					<!-- wp:spacer {"height":"var:preset|spacing|40","width":"0px"} -->
+					<div style="height:var(--wp--preset--spacing--40);width:0px" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer -->
+				</div>
+				<!-- /wp:column -->
 			</div>
-			<!-- /wp:column -->
+			<!-- /wp:columns -->
 
-			<!-- wp:column {"width":"33.33%"} -->
-			<div class="wp-block-column" style="flex-basis:33.33%">
-				<!-- wp:spacer {"height":"var:preset|spacing|40","width":"0px"} -->
-				<div style="height:var(--wp--preset--spacing--40);width:0px" aria-hidden="true" class="wp-block-spacer"></div>
-				<!-- /wp:spacer -->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|80"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"top","justifyContent":"space-between"}} -->
+			<div class="wp-block-group">
+				<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} -->
+					<!-- wp:navigation-link {"label":"Blog","url":"#"} /-->
+
+					<!-- wp:navigation-link {"label":"About","url":"#"} /-->
+
+					<!-- wp:navigation-link {"label":"FAQs","url":"#"} /-->
+
+					<!-- wp:navigation-link {"label":"Authors","url":"#"} /-->
+				<!-- /wp:navigation -->
+
+				<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} -->
+					<!-- wp:navigation-link {"label":"Events","url":"#"} /-->
+
+					<!-- wp:navigation-link {"label":"Shop","url":"#"} /-->
+
+					<!-- wp:navigation-link {"label":"Patterns","url":"#"} /-->
+
+					<!-- wp:navigation-link {"label":"Themes","url":"#"} /-->
+				<!-- /wp:navigation -->
 			</div>
-			<!-- /wp:column -->
-		</div>
-		<!-- /wp:columns -->
-
-		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|80"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"top","justifyContent":"space-between"}} -->
-		<div class="wp-block-group">
-			<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} -->
-				<!-- wp:navigation-link {"label":"Blog","url":"#"} /-->
-
-				<!-- wp:navigation-link {"label":"About","url":"#"} /-->
-
-				<!-- wp:navigation-link {"label":"FAQs","url":"#"} /-->
-
-				<!-- wp:navigation-link {"label":"Authors","url":"#"} /-->
-			<!-- /wp:navigation -->
-
-			<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} -->
-				<!-- wp:navigation-link {"label":"Events","url":"#"} /-->
-
-				<!-- wp:navigation-link {"label":"Shop","url":"#"} /-->
-
-				<!-- wp:navigation-link {"label":"Patterns","url":"#"} /-->
-
-				<!-- wp:navigation-link {"label":"Themes","url":"#"} /-->
-			<!-- /wp:navigation -->
+				<!-- /wp:group -->
 		</div>
 		<!-- /wp:group -->
-	</div>
-	<!-- /wp:group -->
 
-	<!-- wp:spacer {"height":"var:preset|spacing|70"} -->
-	<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
-	<!-- /wp:spacer -->
+		<!-- wp:spacer {"height":"var:preset|spacing|70"} -->
+		<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
 
-	<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignfull">
-		<!-- wp:paragraph { "metadata":{ "bindings":{ "content":{ "source":"twentytwentyfive/copyright" } } }, "fontSize":"small" } -->
-		<p class="has-small-font-size"></p>
-		<!-- /wp:paragraph -->
+		<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+		<div class="wp-block-group alignfull">
+			<!-- wp:paragraph { "metadata":{ "bindings":{ "content":{ "source":"twentytwentyfive/copyright" } } }, "fontSize":"small" } -->
+			<p class="has-small-font-size"></p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph {"fontSize":"small"} -->
-		<p class="has-small-font-size">
-			<?php
-			printf(
-				/* Translators: Designed with WordPress. %1$s: WordPress link. */
-				esc_html__( 'Designed with %1$s', 'twentytwentyfive' ),
-				'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfive' ) ) . '" rel="nofollow">WordPress</a>'
-			);
-			?>
-		</p>
-		<!-- /wp:paragraph -->
-	</div>
-	<!-- /wp:group -->
+			<!-- wp:paragraph {"fontSize":"small"} -->
+			<p class="has-small-font-size">
+				<?php
+				printf(
+					/* Translators: Designed with WordPress. %1$s: WordPress link. */
+					esc_html__( 'Designed with %1$s', 'twentytwentyfive' ),
+					'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfive' ) ) . '" rel="nofollow">WordPress</a>'
+				);
+				?>
+			</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:group -->
 	</div>
 	<!-- /wp:group -->
 </div>


### PR DESCRIPTION
**Description**

Fixes #389 (hopefully).

The site title and tagline uses a Columns block with two columns, the right-most has a spacer. Combined with "Stack on mobile", this causes that spacer block to provide a gap between title, tagline, and navigation items on mobile.

The two columns were 66% and 33% wide. So there wasn't a ton of room for the site title. This PR keeps the columns intact, but makes the first column 100% wide, with the second column not having a width definition, meaning it should expand, and notably keep its height, when stacking on mobile.

@juanfra let me know if this makes sense, is the right read of the intent, and if it helps fix the issue!

**Screenshots**

![test](https://github.com/user-attachments/assets/33a1c863-e1be-45c8-acf7-9d38f0cdc0d3)


**Testing Instructions**

Test the default footer pattern responsively. The title should ideally not wrap.