### PR TITLE
Replace fixed elements with a placeholder

### DIFF
--- a/patterns/page-portfolio-home.php
+++ b/patterns/page-portfolio-home.php
@@ -58,8 +58,7 @@
 					<!-- /wp:post-template -->
 
 					<!-- wp:query-no-results -->
-					<!-- wp:paragraph -->
-					<p>No posts were found.</p>
+					<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","fontSize":"medium"} -->
 					<!-- /wp:paragraph -->
 					<!-- /wp:query-no-results -->
 				</div>
@@ -84,8 +83,7 @@
 					<!-- /wp:post-template -->
 
 					<!-- wp:query-no-results -->
-					<!-- wp:paragraph -->
-					<p>No posts were found.</p>
+					<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","fontSize":"medium"} -->
 					<!-- /wp:paragraph -->
 					<!-- /wp:query-no-results -->
 				</div>
@@ -114,8 +112,7 @@
 			<!-- /wp:post-template -->
 
 			<!-- wp:query-no-results -->
-			<!-- wp:paragraph -->
-			<p>No posts were found.</p>
+			<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","fontSize":"medium"} -->
 			<!-- /wp:paragraph -->
 			<!-- /wp:query-no-results -->
 		</div>
@@ -144,8 +141,7 @@
 					<!-- /wp:post-template -->
 
 					<!-- wp:query-no-results -->
-					<!-- wp:paragraph -->
-					<p>No posts were found.</p>
+					<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","fontSize":"medium"} -->
 					<!-- /wp:paragraph -->
 					<!-- /wp:query-no-results -->
 				</div>
@@ -170,8 +166,7 @@
 					<!-- /wp:post-template -->
 
 					<!-- wp:query-no-results -->
-					<!-- wp:paragraph -->
-					<p>No posts were found.</p>
+					<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","fontSize":"medium"} -->
 					<!-- /wp:paragraph -->
 					<!-- /wp:query-no-results -->
 				</div>
@@ -200,8 +195,7 @@
 			<!-- /wp:post-template -->
 
 			<!-- wp:query-no-results -->
-			<!-- wp:paragraph -->
-			<p>No posts were found.</p>
+			<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","fontSize":"medium"} -->
 			<!-- /wp:paragraph -->
 			<!-- /wp:query-no-results -->
 		</div>


### PR DESCRIPTION
**Description**

This solves the issue where the **Portfolio Homepage** template was showing multiple "No posts were found." messages. By using the placeholder we can show this message only in the editor and avoid displaying it on the front end.

**Screenshots**

Used two languages, Spanish and German, to better highlight what's text produced by WordPress (the localized text) and which one was the fixed text from the pattern (text in English).

### Previously, the editor was showing multiple "No posts were found."
<img width="1274" alt="Screenshot 2024-09-24 at 23 35 04" src="https://github.com/user-attachments/assets/3ac6bb52-da78-427f-ad6b-2ac98b3ae8cc">

### Which were also visible on the front end
<img width="1281" alt="Screenshot 2024-09-24 at 23 36 18" src="https://github.com/user-attachments/assets/7dec7e52-6432-43a1-abc3-2af166d8b5e9">

### With this approach, the messages are shown as placeholders in the editor
<img width="1203" alt="Screenshot 2024-09-25 at 00 42 36" src="https://github.com/user-attachments/assets/827df7d4-dd84-47dd-91a2-c3dcd4816c4d">

### and the messages aren't visible on the front end
<img width="1597" alt="Screenshot 2024-09-25 at 00 30 04" src="https://github.com/user-attachments/assets/1c82d7f0-db4d-4ea7-acd8-d4908cbee764">


**Testing Instructions**

1. Activate the theme.
2. Add a page.
3. Select the Portfolio Homepage pattern.
    <img width="344" alt="Screenshot 2024-09-25 at 00 46 45" src="https://github.com/user-attachments/assets/77c36b2e-a5e1-488c-affb-7b54ce5bf5a7">
4. Verify the placeholders are there.
5. Publish the page and check on the front end that the placeholders aren't visible.
