### PR TITLE
Newsletter signup: Add the aside element and translation functions

### DIFF
--- a/patterns/newsletter-signup.php
+++ b/patterns/newsletter-signup.php
@@ -11,24 +11,24 @@
  */
 
 ?>
-<!-- wp:cover {"overlayColor":"accent-1","isUserOverlayColor":true,"minHeight":460,"isDark":false,"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-cover alignfull is-light" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50);min-height:460px"><span aria-hidden="true" class="wp-block-cover__background has-accent-1-background-color has-background-dim-100 has-background-dim"></span>
+<!-- wp:cover {"tagName":"aside","overlayColor":"accent-1","isUserOverlayColor":true,"minHeight":460,"isDark":false,"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+<aside class="wp-block-cover alignfull is-light" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50);min-height:460px"><span aria-hidden="true" class="wp-block-cover__background has-accent-1-background-color has-background-dim-100 has-background-dim"></span>
 <div class="wp-block-cover__inner-container">
 	<!-- wp:heading {"textAlign":"center","fontSize":"x-large"} -->
-	<h2 class="wp-block-heading has-text-align-center has-x-large-font-size">Sign up to get daily stories</h2>
+	<h2 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html_x( 'Sign up to get daily stories', 'Newsletter pattern sample text', 'twentytwentyfive' ); ?></h2>
 	<!-- /wp:heading -->
 
 	<!-- wp:paragraph {"align":"center"} -->
-	<p class="has-text-align-center">Get access to a curated collection of moments in time featuring<br>photographs from historical relevance.</p>
+	<p class="has-text-align-center"><?php echo wp_kses_post( _x( 'Get access to a curated collection of moments in time featuring<br>photographs from historical relevance.', 'Newsletter pattern sample text', 'twentytwentyfive' ) ); ?></p>
 	<!-- /wp:paragraph -->
 
 	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 	<div class="wp-block-buttons">
 		<!-- wp:button {"textAlign":"center"} -->
-		<div class="wp-block-button"><a class="wp-block-button__link has-text-align-center wp-element-button">Subscribe</a></div>
+		<div class="wp-block-button"><a class="wp-block-button__link has-text-align-center wp-element-button"><?php echo esc_html_x( 'Subscribe', 'Newsletter pattern sample text', 'twentytwentyfive' ); ?></a></div>
 		<!-- /wp:button -->
 	</div>
 	<!-- /wp:buttons -->
 </div>
-</div>
+</aside>
 <!-- /wp:cover -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This pull request adds the translation functions to the newsletter signup pattern.

It also changes the outer element from a `<div>` to an `<aside>`.
By using an aside, the pattern can be placed between the `<main>` element and the `<footer> `, and pass the [ARIA Landmark Roles](https://make.wordpress.org/themes/handbook/review/accessibility/required/#aria-landmark-roles) requirement for the accessibility-ready tag.

Partial for https://github.com/WordPress/twentytwentyfive/issues/160

**Testing Instructions**
Place the Newsletter Sign Up pattern.
Confirm that the text displays correctly after the addition of the translation functions.
Confirm that the outer element uses an aside.