### PR TITLE
Try: Fix quote styles.

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1195,7 +1195,7 @@
 			"core/quote": {
 				"border": {
 					"style": "solid",
-					"width": "0 2px 0 2px",
+					"width": "0 0 0 2px",
 					"color": "var:preset|color|contrast"
 				},
 				"spacing": {
@@ -1226,7 +1226,7 @@
 						"css": "& sub { font-size: 0.65em }"
 					}
 				},
-				"css": "&.has-text-align-right { border-left: 0; padding-left: 0; } &.has-text-align-center { border-inline: 0; padding-inline: 0; } &:not(.has-text-align-right):not(.has-text-align-center) { border-right: 0; padding-right: 0; }",
+				"css": "&.has-text-align-right { border-width: 0 2px 0 0; } &.has-text-align-center { border-width: 0;border-inline: 0; padding-inline: 0; }",
 				"variations": {
 					"plain": {
 						"border": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Fixing the border styles of the quote so that these respond to what's set via UI.

Closes https://github.com/WordPress/twentytwentyfive/issues/370

**Screenshots**

https://github.com/user-attachments/assets/60d0b5e2-5046-4013-b7e3-613c94c81e35


<!-- Add screenshots of the change, if applicable -->

**Testing Instructions**

1 Add a Quote block to any post/page.
2. Set Border to 2px without changing the left/default alignment.
3. Update the post/page and check the borders on both the Editor-end and front-end.
4. Change the alignment to Center.
5. Update the post/page and and check the alignment (and borders) on both the Editor-end and front-end.
6. Change the alignment to Right.
7. Update the post/page and and check the alignment (and borders) on both the Editor-end and front-end.
