### PR TITLE
Simplify button and link styles

### DIFF
--- a/assets/css/button-outline.css
+++ b/assets/css/button-outline.css
@@ -1,6 +1,3 @@
-.wp-block-button.is-style-outline
-	> .wp-block-button__link:not(.has-text-color, .has-background):hover {
-	background-color: var(--wp--preset--color--contrast, transparent);
-	color: var(--wp--preset--color--base);
-	border-color: var(--wp--preset--color--contrast, currentColor);
+.wp-block-button.is-style-outline > .wp-block-button__link:not(.has-background):hover {
+	background-color: color-mix(in srgb, var(--wp--preset--color--contrast) 5%, transparent);
 }

--- a/styles/blocks/section-1.json
+++ b/styles/blocks/section-1.json
@@ -19,19 +19,6 @@
 					"text": "color-mix(in srgb, currentColor 25%, transparent)"
 				}
 			}
-		},
-		"elements": {
-			"button": {
-				"color": {
-					"background": "var:preset|color|contrast",
-					"text": "var:preset|color|base"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var:preset|color|contrast"
-				}
-			}
 		}
 	}
 }

--- a/styles/blocks/section-2.json
+++ b/styles/blocks/section-2.json
@@ -23,13 +23,14 @@
 		"elements": {
 			"button": {
 				"color": {
-					"background": "var:preset|color|contrast",
-					"text": "var:preset|color|base"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var:preset|color|accent-2"
+					"background": "var:preset|color|accent-2",
+					"text": "var:preset|color|accent-3"
+				},
+				":hover": {
+					"color": {
+						"background": "color-mix(in srgb, var(--wp--preset--color--accent-2) 85%, transparent)",
+						"text": "var:preset|color|accent-3"
+					}
 				}
 			}
 		}

--- a/styles/blocks/section-3.json
+++ b/styles/blocks/section-3.json
@@ -19,19 +19,6 @@
 					"text": "color-mix(in srgb, currentColor 25%, transparent)"
 				}
 			}
-		},
-		"elements": {
-			"button": {
-				"color": {
-					"background": "var:preset|color|contrast",
-					"text": "var:preset|color|base"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var:preset|color|contrast"
-				}
-			}
 		}
 	}
 }

--- a/styles/blocks/section-4.json
+++ b/styles/blocks/section-4.json
@@ -25,11 +25,12 @@
 				"color": {
 					"background": "var:preset|color|base",
 					"text": "var:preset|color|contrast"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var:preset|color|base"
+				},
+				":hover": {
+					"color": {
+						"background": "color-mix(in srgb, var(--wp--preset--color--base) 80%, transparent)",
+						"text": "var:preset|color|contrast"
+					}
 				}
 			}
 		}

--- a/styles/blocks/section-5.json
+++ b/styles/blocks/section-5.json
@@ -19,19 +19,6 @@
 					"text": "color-mix(in srgb, currentColor 25%, transparent)"
 				}
 			}
-		},
-		"elements": {
-			"button": {
-				"color": {
-					"background": "var:preset|color|contrast",
-					"text": "var:preset|color|base"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var:preset|color|contrast"
-				}
-			}
 		}
 	}
 }

--- a/theme.json
+++ b/theme.json
@@ -992,6 +992,11 @@
 					}
 				}
 			},
+			"core/buttons": {
+				"spacing": {
+					"blockGap": "16px"
+				}
+			},
 			"core/code": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|fira-code",

--- a/theme.json
+++ b/theme.json
@@ -967,29 +967,18 @@
 				}
 			},
 			"core/button": {
-				"typography": {
-					"fontSize": "var:preset|font-size|medium"
-				},
-				"spacing": {
-					"padding": {
-						"bottom": "1rem",
-						"left": "2.25rem",
-						"right": "2.25rem",
-						"top": "1rem"
-					}
-				},
 				"variations": {
 					"outline": {
 						"border": {
-							"color": "var:preset|color|contrast",
+							"color": "currentColor",
 							"width": "1px"
 						},
 						"spacing": {
 							"padding": {
-								"bottom": "1rem",
-								"left": "2.25rem",
-								"right": "2.25rem",
-								"top": "1rem"
+								"bottom": "calc(1rem - 1px)",
+								"left": "calc(2.25rem - 1px)",
+								"right": "calc(2.25rem - 1px)",
+								"top": "calc(1rem - 1px)"
 							}
 						}
 					}
@@ -1382,17 +1371,7 @@
 					"background": "var:preset|color|contrast",
 					"text": "var:preset|color|base"
 				},
-				":active": {
-					"color": {
-						"background": "var:preset|color|accent-1",
-						"text": "var:preset|color|contrast"
-					}
-				},
 				":focus": {
-					"color": {
-						"background": "var:preset|color|accent-1",
-						"text": "var:preset|color|contrast"
-					},
 					"outline": {
 						"color": "var:preset|color|primary",
 						"offset": "2px",
@@ -1402,18 +1381,23 @@
 				},
 				":hover": {
 					"color": {
-						"background": "var:preset|color|accent-1",
-						"text": "var:preset|color|contrast"
+						"background": "color-mix(in srgb, var(--wp--preset--color--contrast) 85%, transparent)",
+						"text": "var:preset|color|base"
 					},
 					"border": {
 						"color": "transparent"
 					}
 				},
-				"border": {
-					"color": "var:preset|color|contrast",
-					"radius": "100px",
-					"width": "1px",
-					"style": "solid"
+				"spacing": {
+					"padding": {
+						"bottom": "1rem",
+						"left": "2.25rem",
+						"right": "2.25rem",
+						"top": "1rem"
+					}
+				},
+				"typography": {
+					"fontSize": "var:preset|font-size|medium"
 				}
 			},
 			"caption": {
@@ -1465,7 +1449,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var:preset|color|contrast"
+					"text": "currentColor"
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Simplifies button and link styles, reducing conflicts between block style variations (pattern/section styles). 

- Reduce custom code in button-outline.css (we should consider moving this to theme.json)
- Reduce dependencies on setting link color in section styles, as parent theme.json uses currentColor. This makes it easier to change colors of a section without having to also change its link colors. 
- Remove the hover effect applying accent-1, instead using a color-mix of the button's background color. This reduces the mini conflicts with style variations.
- Make button styles for the outline variation match visually to the default.  
 
**Screenshots**

![CleanShot 2024-09-25 at 15 37 57](https://github.com/user-attachments/assets/0a348552-068e-4bec-b4ad-00a595e38455)


Closes https://github.com/WordPress/twentytwentyfive/issues/407.