### PR TITLE
Rename primary/secondary/opacity colors to accents

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -35,18 +35,18 @@
 				},
 				{
 					"color": "#686868",
-					"name": "Primary",
-					"slug": "primary"
+					"name": "Accent 4",
+					"slug": "accent-4"
 				},
 				{
 					"color": "#FBFAF3",
-					"name": "Secondary",
-					"slug": "secondary"
+					"name": "Accent 5",
+					"slug": "accent-5"
 				},
 				{
 					"color": "#11111133",
-					"name": "Opacity 20%",
-					"slug": "opacity-20"
+					"name": "Accent 6",
+					"slug": "accent-6"
 				}
 			]
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

Resolves #415

**Description**

As mentioned in the original issue, it is not clear what significance the `Primary`, `Secondary` and `Opacity` colors have and should actually be accent colors. This PR changes the `Primary` color to `Accent 4`, `Secondary` to `Accent 5` and `Opacity` to `Accent 6`.

**Screenshots**

<img width="299" alt="image" src="https://github.com/user-attachments/assets/dc082ba4-f8c2-4379-832a-455b1c183d3d">
<img width="321" alt="image" src="https://github.com/user-attachments/assets/5b6baffd-bbf2-40d5-8d11-316ee0413207">
<img width="299" alt="image" src="https://github.com/user-attachments/assets/85c4b644-6e5f-451a-8f81-5363dcbf923d">


**Testing Instructions**

- Edit the global styles.
- Click on 'Palette'.
- Hover over each color to see their name appear in a tooltip.