### PR TITLE
Add better core/columns spacing blockGap default

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -995,6 +995,14 @@
 					}
 				}
 			},
+			"core/columns": {
+				"spacing": {
+					"blockGap": {
+						"left": "var:preset|spacing|50",
+						"top": "var:preset|spacing|50"
+					}
+				}
+			},
 			"core/code": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|fira-code",


### PR DESCRIPTION
Instead of having to define them within every pattern, just define the value in theme.json instead. 

### Before

![CleanShot 2024-09-25 at 17 10 24](https://github.com/user-attachments/assets/0998a87c-2185-4648-b6dc-d9227f0a484e)

### After 

![CleanShot 2024-09-25 at 17 10 10](https://github.com/user-attachments/assets/50edc62e-5962-4633-8a53-20ce55cdccdf)

