### PR TITLE
Vertical header: Fix block validation error

### DIFF
--- a/patterns/vertical-header.php
+++ b/patterns/vertical-header.php
@@ -15,7 +15,7 @@
 <!-- wp:group {"align":"wide","style":{"position":{"type":"sticky","top":"0px"},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"default"}} -->
 <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
 	<!-- wp:group {"align":"wide","style":{"dimensions":{"minHeight":"100vh"}},"layout":{"type":"constrained","justifyContent":"center"}} -->
-	<div class="wp-block-group alignwide" style="min-height:100vh;padding-right:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+	<div class="wp-block-group alignwide" style="min-height:100vh;">
 		<!-- wp:group {"align":"full","layout":{"type":"flex","orientation":"vertical","justifyContent":"center","verticalAlignment":"center"}} -->
 		<div class="wp-block-group alignfull">
 			<!-- wp:navigation {"overlayMenu":"always","style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}},"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal","flexWrap":"wrap"}} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
When the padding setting was removed from the pattern in https://github.com/WordPress/twentytwentyfive/pull/397,
the CSS was left inside the style attribute, which caused a block validation error.

This PR removes the CSS.

**Testing Instructions**
View the vertical header in the editor and confirm there is no block validation error.