### PR TITLE
Update: Improve "No results" order, style, and phrasing.

### DIFF
--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -36,7 +36,7 @@
 
 	<!-- wp:query-no-results -->
 		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","fontSize":"medium"} -->
-		<p class="has-medium-font-size"><?php esc_html_e( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?></p>
+		<p class="has-medium-font-size"><?php esc_html_e( 'Sorry, but nothing was found. Please try a search with different keywords.', 'twentytwentyfive' ); ?></p>
 		<!-- /wp:paragraph -->
 	<!-- /wp:query-no-results -->
 </div>

--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -36,7 +36,7 @@
 
 	<!-- wp:query-no-results -->
 		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","fontSize":"medium"} -->
-		<p class="has-medium-font-size"><?php esc_html_e( 'No posts were found.', 'twentytwentyfive' ); ?></p>
+		<p class="has-medium-font-size"><?php esc_html_e( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?></p>
 		<!-- /wp:paragraph -->
 	<!-- /wp:query-no-results -->
 </div>

--- a/patterns/news-blog-home-template.php
+++ b/patterns/news-blog-home-template.php
@@ -37,7 +37,7 @@
 						<!-- /wp:post-template -->
 						<!-- wp:query-no-results -->
 							<!-- wp:paragraph -->
-							<p>No posts were found.</p>
+							<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 							<!-- /wp:paragraph -->
 						<!-- /wp:query-no-results -->
 					</div>
@@ -55,7 +55,7 @@
 						<!-- /wp:post-template -->
 						<!-- wp:query-no-results -->
 							<!-- wp:paragraph -->
-							<p>No posts were found.</p>
+							<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 							<!-- /wp:paragraph -->
 						<!-- /wp:query-no-results -->
 					</div>
@@ -80,7 +80,7 @@
 					<!-- /wp:post-template -->
 					<!-- wp:query-no-results -->
 						<!-- wp:paragraph -->
-						<p>No posts were found.</p>
+						<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 						<!-- /wp:paragraph -->
 					<!-- /wp:query-no-results -->
 				</div>
@@ -104,7 +104,7 @@
 						<!-- /wp:post-template -->
 						<!-- wp:query-no-results -->
 							<!-- wp:paragraph -->
-							<p>No posts were found.</p>
+							<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 							<!-- /wp:paragraph -->
 						<!-- /wp:query-no-results -->
 					</div>
@@ -122,7 +122,7 @@
 						<!-- /wp:post-template -->
 						<!-- wp:query-no-results -->
 							<!-- wp:paragraph -->
-							<p>No posts were found.</p>
+							<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 							<!-- /wp:paragraph -->
 						<!-- /wp:query-no-results -->
 					</div>
@@ -151,7 +151,7 @@
 			<!-- /wp:post-template -->
 			<!-- wp:query-no-results -->
 				<!-- wp:paragraph -->
-				<p>No posts were found.</p>
+				<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 				<!-- /wp:paragraph -->
 			<!-- /wp:query-no-results -->
 		</div>
@@ -174,7 +174,7 @@
 			<!-- /wp:post-template -->
 			<!-- wp:query-no-results -->
 				<!-- wp:paragraph -->
-				<p>No posts were found.</p>
+				<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 				<!-- /wp:paragraph -->
 			<!-- /wp:query-no-results -->
 			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->

--- a/patterns/news-blog-query-loop.php
+++ b/patterns/news-blog-query-loop.php
@@ -51,7 +51,7 @@
 
 <!-- wp:query-no-results -->
 <!-- wp:paragraph -->
-<p>No posts were found.</p>
+<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 <!-- /wp:paragraph -->
 <!-- /wp:query-no-results -->
 

--- a/patterns/news-blog-with-featured-posts-grid-template.php
+++ b/patterns/news-blog-with-featured-posts-grid-template.php
@@ -32,7 +32,7 @@
 			<!-- /wp:post-template -->
 			<!-- wp:query-no-results -->
 				<!-- wp:paragraph {"align":"center","placeholder":"Add text or blocks that will display when a query returns no results."} -->
-				<p class="has-text-align-center">No posts were found.</p>
+				<p class="has-text-align-center"><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 				<!-- /wp:paragraph -->
 			<!-- /wp:query-no-results -->
 		</div>
@@ -57,7 +57,7 @@
 				<!-- /wp:post-template -->
 				<!-- wp:query-no-results -->
 				<!-- wp:paragraph -->
-				<p>No posts were found.</p>
+				<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 				<!-- /wp:paragraph -->
 				<!-- /wp:query-no-results -->
 			</div>
@@ -75,7 +75,7 @@
 				<!-- /wp:post-template -->
 				<!-- wp:query-no-results -->
 				<!-- wp:paragraph -->
-				<p>No posts were found.</p>
+				<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 				<!-- /wp:paragraph -->
 				<!-- /wp:query-no-results -->
 			</div>
@@ -100,7 +100,7 @@
 			<!-- /wp:post-template -->
 			<!-- wp:query-no-results -->
 			<!-- wp:paragraph -->
-			<p>No posts were found.</p>
+			<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 			<!-- /wp:paragraph -->
 			<!-- /wp:query-no-results -->
 		</div>

--- a/patterns/news-blog-with-sidebar-template.php
+++ b/patterns/news-blog-with-sidebar-template.php
@@ -59,7 +59,7 @@
 				<!-- /wp:post-template -->
 				<!-- wp:query-no-results -->
 					<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results.","fontSize":"medium"} -->
-					<p class="has-medium-font-size">No posts were found.</p>
+					<p class="has-medium-font-size"><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 					<!-- /wp:paragraph -->
 				<!-- /wp:query-no-results -->
 			</div>
@@ -116,7 +116,7 @@
 		<!-- /wp:group -->
 		<!-- wp:query-no-results -->
 			<!-- wp:paragraph -->
-			<p>No posts were found.</p>
+			<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 			<!-- /wp:paragraph -->
 		<!-- /wp:query-no-results -->
 	</div>

--- a/patterns/page-portfolio-home.php
+++ b/patterns/page-portfolio-home.php
@@ -59,7 +59,7 @@
 
 					<!-- wp:query-no-results -->
 					<!-- wp:paragraph -->
-					<p>No posts were found.</p>
+					<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 					<!-- /wp:paragraph -->
 					<!-- /wp:query-no-results -->
 				</div>
@@ -85,7 +85,7 @@
 
 					<!-- wp:query-no-results -->
 					<!-- wp:paragraph -->
-					<p>No posts were found.</p>
+					<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 					<!-- /wp:paragraph -->
 					<!-- /wp:query-no-results -->
 				</div>
@@ -115,7 +115,7 @@
 
 			<!-- wp:query-no-results -->
 			<!-- wp:paragraph -->
-			<p>No posts were found.</p>
+			<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 			<!-- /wp:paragraph -->
 			<!-- /wp:query-no-results -->
 		</div>
@@ -145,7 +145,7 @@
 
 					<!-- wp:query-no-results -->
 					<!-- wp:paragraph -->
-					<p>No posts were found.</p>
+					<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 					<!-- /wp:paragraph -->
 					<!-- /wp:query-no-results -->
 				</div>
@@ -171,7 +171,7 @@
 
 					<!-- wp:query-no-results -->
 					<!-- wp:paragraph -->
-					<p>No posts were found.</p>
+					<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 					<!-- /wp:paragraph -->
 					<!-- /wp:query-no-results -->
 				</div>
@@ -201,7 +201,7 @@
 
 			<!-- wp:query-no-results -->
 			<!-- wp:paragraph -->
-			<p>No posts were found.</p>
+			<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 			<!-- /wp:paragraph -->
 			<!-- /wp:query-no-results -->
 		</div>

--- a/patterns/photo-blog-posts.php
+++ b/patterns/photo-blog-posts.php
@@ -18,7 +18,7 @@
 		<div class="wp-block-group">
 		<!-- wp:query-no-results -->
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center"><?php echo esc_html_x( '<?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?></p>
+		<p class="has-text-align-center"><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 		<!-- /wp:paragraph -->
 		<!-- /wp:query-no-results -->
 	</div>

--- a/patterns/photo-blog-posts.php
+++ b/patterns/photo-blog-posts.php
@@ -18,7 +18,7 @@
 		<div class="wp-block-group">
 		<!-- wp:query-no-results -->
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center"><?php echo esc_html_x( 'No posts were found.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?></p>
+		<p class="has-text-align-center"><?php echo esc_html_x( '<?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?></p>
 		<!-- /wp:paragraph -->
 		<!-- /wp:query-no-results -->
 	</div>

--- a/patterns/posts-personal-blog.php
+++ b/patterns/posts-personal-blog.php
@@ -28,7 +28,7 @@
 	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 		<!-- wp:query-no-results -->
 		<!-- wp:paragraph -->
-		<p><?php echo esc_html_x( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?></p>
+		<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?></p>
 		<!-- /wp:paragraph -->
 		<!-- /wp:query-no-results -->
 	</div>

--- a/patterns/posts-personal-blog.php
+++ b/patterns/posts-personal-blog.php
@@ -14,15 +14,6 @@
 ?>
 <!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"layout":{"type":"default"}} -->
 <div class="wp-block-query">
-	<!-- wp:group {"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group">
-		<!-- wp:query-no-results -->
-		<!-- wp:paragraph -->
-		<p><?php echo esc_html_x( 'No posts were found.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?></p>
-		<!-- /wp:paragraph -->
-		<!-- /wp:query-no-results -->
-	</div>
-	<!-- /wp:group -->
 	<!-- wp:post-template {"align":"full","layout":{"type":"default"}} -->
 		<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"default"}} -->
 		<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
@@ -33,6 +24,15 @@
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+		<!-- wp:query-no-results -->
+		<!-- wp:paragraph -->
+		<p><?php echo esc_html_x( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?></p>
+		<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:group -->
 	<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignwide">
 		<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->

--- a/patterns/text-only-blog-posts.php
+++ b/patterns/text-only-blog-posts.php
@@ -16,7 +16,7 @@
 	<div class="wp-block-group">
 		<!-- wp:query-no-results {"align":"wide","fontSize":"medium"} -->
 			<!-- wp:paragraph -->
-			<p>No posts were found.</p>
+			<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 			<!-- /wp:paragraph -->
 		<!-- /wp:query-no-results -->
 	</div>

--- a/patterns/vertical-header-right-aligned-posts.php
+++ b/patterns/vertical-header-right-aligned-posts.php
@@ -46,7 +46,7 @@
 
 	<!-- wp:query-no-results -->
 		<!-- wp:paragraph -->
-		<p>No posts were found.</p>
+		<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?>.</p>
 		<!-- /wp:paragraph -->
 	<!-- /wp:query-no-results -->
 </div>


### PR DESCRIPTION
**Description**

Partially related to #395, 

When opening the default blog home template in the site editor, the first thing you see is "Blog", followed by "No posts found."

![before](https://github.com/user-attachments/assets/641d0964-7278-4393-ad4c-603d3a314804)

This can easily be misunderstood as an error, especially since posts on your site are right there, showing up below.

What's going on behind the scenes—and this is worth improving in the block editor at the soure itself—is that the "No results" block has to be included in the query loop so that you can style it. but on the frontend, it will only actually show up if you really do have no results to show.

This PR does a few small things:

* It moves the "No results" section _below_ the posts. This mitigates the feeling of this being an error, and will work the same since either section will be hidden depending on the query.
* It rephrases the text to be slightly friendlier.
* It adds the same top/bottom padding to its Group container, as the post itself has, so that there's a consistent gap between title, post|no results, and pagination.

Result:

![after](https://github.com/user-attachments/assets/5a23be4d-8b01-4c63-b244-5af8fa813c63)

**Testing Instructions**

Test Blog home (and other archive templates) in the site editor, observe the new message showing up below the list of posts. 