### PR TITLE
Right-aligned posts: Hide the pattern from the inserter

### DIFF
--- a/patterns/vertical-header-right-aligned-posts.php
+++ b/patterns/vertical-header-right-aligned-posts.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Title: Blog posts for the right aligned blog
+ * Title: Right-aligned posts
  * Slug: twentytwentyfive/right-aligned-posts
- * Categories: query
- * Block Types: core/query
- * Description:
+ * Inserter: no
  *
  * @package WordPress
  * @subpackage Twenty_Twenty_Five


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
The main purpose of this query loop pattern is to display the posts in the design with the vertical header and right-aligned content.

As a stand-alone pattern, it is not designed to be used in just any template, page or post.
I suggest hiding it from the inserter. **I don't feel strongly if there are other solutions to improve its use and the preview.**

**Testing Instructions**

In the editor, preview the patterns in the Posts category. Confirm the pattern is not available.
Then test the templates with the vertical header and confirm that the pattern is loading.
