### PR TITLE
Alt: Just the new text-styles

### DIFF
--- a/styles/blocks/01-display.json
+++ b/styles/blocks/01-display.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"title": "Display",
+	"slug": "text-display",
+	"blockTypes": ["core/heading", "core/paragraph"],
+	"styles": {
+		"typography": {
+			"fontSize": "var:preset|font-size|xx-large",
+			"lineHeight": "1.2"
+		}
+	}
+}

--- a/styles/blocks/02-subtitle.json
+++ b/styles/blocks/02-subtitle.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
+	"title": "Subtitle",
+	"slug": "text-subtitle",
+	"blockTypes": ["core/heading", "core/paragraph"],
+	"styles": {
+		"typography": {
+			"fontSize": "var:preset|font-size|x-large",
+			"lineHeight": "1.2"
+		}
+	}
+}

--- a/styles/blocks/03-annotation.json
+++ b/styles/blocks/03-annotation.json
@@ -1,27 +1,28 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 3,
-	"title": "Pill",
-	"slug": "pill",
+	"title": "Annotation",
+	"slug": "text-annotation",
 	"blockTypes": ["core/heading", "core/paragraph"],
 	"styles": {
+		"css": "display: inline-flex",
 		"typography": {
 			"fontSize": "var:preset|font-size|small",
-			"lineHeight": "1",
+			"lineHeight": "1.5",
 			"letterSpacing": "normal"
 		},
 		"border": {
 			"color": "currentColor",
 			"style": "solid",
 			"width": "1px",
-			"radius": "999px"
+			"radius": "16px"
 		},
 		"spacing": {
 			"padding": {
-				"top": "0.31rem",
-				"right": "var:preset|spacing|20",
-				"bottom": "0.31rem",
-				"left": "var:preset|spacing|20"
+				"top": "0.2rem",
+				"right": "0.6rem",
+				"bottom": "0.25rem",
+				"left": "0.6rem"
 			}
 		},
 		"elements": {


### PR DESCRIPTION
**Description**

Alternative to #330 and #388. 

Adds two new text styles, Display and Subtitle, and renames "Pill" to "Annotation", as discussed [here](https://github.com/WordPress/twentytwentyfive/pull/388#issuecomment-2376311686). Happy to update "Annotation" further, depending on your feedback.

The reason this is a separate PR is that this includes _only_ the .json files, and no pattern changes. We can explore those changes separately depending on first landing this. 

Penny for your thoughts! 🙏 