### PR TITLE
News blog single post with sidebar: Replace the H2 on the Post title with H1

### DIFF
--- a/patterns/news-blog-single-post-with-sidebar-template.php
+++ b/patterns/news-blog-single-post-with-sidebar-template.php
@@ -24,7 +24,7 @@
 			<!-- wp:spacer {"height":"var:preset|spacing|80"} -->
 			<div style="height:var(--wp--preset--spacing--80)" aria-hidden="true" class="wp-block-spacer"></div>
 			<!-- /wp:spacer -->
-			<!-- wp:post-title {"align":"wide","fontSize":"xx-large"} /-->
+			<!-- wp:post-title {"level":1,"align":"wide","fontSize":"xx-large"} /-->
 			<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
 			<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
 			<!-- /wp:spacer -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
"News blog single post with sidebar" was missing the H1. In this single post view, the post title was an H2.
The PR updates this to an H1, and keeps the size.


**Testing Instructions**

View the code and confirm the title uses an H1.
Or select the single post template, open the Template tab and the Design panel. Select the News blog single post with sidebar, and save.
Confirm that the post title is an H1.
