### PR TITLE
Add: Business & shop homepages

### DIFF
--- a/patterns/page-business-home.php
+++ b/patterns/page-business-home.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Title: Business Homepage
+ * Slug: twentytwentyfive/page-business-home
+ * Categories: twentytwentyfive_page, posts, featured
+ * Keywords: starter
+ * Block Types: core/post-content
+ * Post Types: page, wp_template
+ * Viewport width: 1400
+ * Description: A business homepage pattern.
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull">
+	<!-- wp:pattern {"slug":"twentytwentyfive/cta-centered-heading"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfive/overlap-images-and-paragraph"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfive/services-three-columns"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfive/testimonials-review-large-image-right"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfive/pricing-2-col"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfive/newsletter-sign-up"} /-->
+</div>
+<!-- /wp:group -->

--- a/patterns/page-shop-home.php
+++ b/patterns/page-shop-home.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Title: Shop Homepage
+ * Slug: twentytwentyfive/page-shop-home
+ * Categories: twentytwentyfive_page, posts, featured
+ * Keywords: starter
+ * Block Types: core/post-content
+ * Post Types: page, wp_template
+ * Viewport width: 1400
+ * Description: A shop homepage pattern.
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull">
+	<!-- wp:pattern {"slug":"twentytwentyfive/intro-short-heading-image"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfive/grid-with-categories"} /-->
+	<!-- wp:pattern {"slug":"twentytwentyfive/instagram-grid"} /-->
+</div>
+<!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

<!-- Describe the purpose or reason for the pull request -->
Adding

- [Business home](https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=1-3406&t=DWoVwZDlj9tFQiL2-1)
- [Shop home](https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=1-3400&t=DWoVwZDlj9tFQiL2-1)

**Screenshots**

https://github.com/user-attachments/assets/093a1e84-4843-423d-9e4d-71f003faf3a3

**Testing Instructions**

1. Create a page.
2. See the new pages are in the modal.
3. Insert both and confirm they use the design's same pattern compilation.
