### PR TITLE
Fix: Remove icon from link format pattern for RTL purposes.

### DIFF
--- a/patterns/format-link.php
+++ b/patterns/format-link.php
@@ -18,12 +18,10 @@
 	<!-- /wp:paragraph -->
 
 	<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|accent-4"}}}},"textColor":"accent-4","fontSize":"medium","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group has-accent-4-color has-text-color has-link-color has-medium-font-size"><!-- wp:paragraph -->
+	<div class="wp-block-group has-accent-4-color has-text-color has-link-color has-medium-font-size">
+		<!-- wp:paragraph -->
 		<p><a href="#">https://example.com</a></p>
 		<!-- /wp:paragraph -->
-
-		<!-- wp:paragraph -->
-		<p>↗</p>
-		<!-- /wp:paragraph --></div>
-	<!-- /wp:group --></div>
+	<!-- /wp:group -->
+	</div>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

We have an arrow icon that could be problematic in RTL languages, as the expectation would be that the icon points to the left. In order to do that, we would have to add custom CSS to flip it horizontally, and I believe that's something that we want to avoid. The goal of this PR is to remove the icon for now, and maybe revisit the inclusion later, with a solution for RTL languages.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->
<img width="687" alt="Screenshot 2024-09-27 at 17 53 23" src="https://github.com/user-attachments/assets/90c85f8f-dd91-4e1e-b384-cfb9eadb532c">


**Testing Instructions**

1. Create a page.
2. Add the pattern.
3. Confirm that the icon is no longer there.
