### PR TITLE
Try: Move the CSS for the outline button :hover style to theme.json

### DIFF
--- a/assets/css/button-outline.css
+++ b/assets/css/button-outline.css
@@ -1,3 +1,0 @@
-.wp-block-button.is-style-outline > .wp-block-button__link:not(.has-background):hover {
-	background-color: color-mix(in srgb, var(--wp--preset--color--contrast) 5%, transparent);
-}

--- a/functions.php
+++ b/functions.php
@@ -67,37 +67,6 @@ endif;
 add_action( 'wp_enqueue_scripts', 'twentytwentyfive_enqueue_styles' );
 
 /**
- * Enqueue custom block stylesheets.
- */
-if ( ! function_exists( 'twentytwentyfive_block_stylesheets' ) ) :
-	/**
-	 * Enqueue custom block stylesheets.
-	 *
-	 * @since Twenty Twenty-Five 1.0
-	 * @return void
-	 */
-	function twentytwentyfive_block_stylesheets() {
-		/**
-		 * The wp_enqueue_block_style() function allows us to enqueue a stylesheet
-		 * for a specific block. These will only get loaded when the block is rendered
-		 * (both in the editor and on the front end), improving performance
-		 * and reducing the amount of data requested by visitors.
-		 */
-		wp_enqueue_block_style(
-			'core/button',
-			array(
-				'handle' => 'twentytwentyfive-button-style-outline',
-				'src'    => get_parent_theme_file_uri( 'assets/css/button-outline.css' ),
-				'ver'    => wp_get_theme( get_template() )->get( 'Version' ),
-				'path'   => get_parent_theme_file_path( 'assets/css/button-outline.css' ),
-			)
-		);
-	}
-endif;
-
-add_action( 'init', 'twentytwentyfive_block_stylesheets' );
-
-/**
  * Register custom block styles.
  */
 if ( ! function_exists( 'twentytwentyfive_block_styles' ) ) :

--- a/theme.json
+++ b/theme.json
@@ -962,6 +962,7 @@
 							"color": "currentColor",
 							"width": "1px"
 						},
+						"css": ".wp-block-button__link:not(.has-background):hover {background-color:color-mix(in srgb, var(--wp--preset--color--contrast) 5%, transparent);}",
 						"spacing": {
 							"padding": {
 								"bottom": "calc(1rem - 1px)",


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
In this PR I am moving the CSS for the hover style for the outline button variation to theme.json.
Note, I was not able to make it work with the `>` combinator so I removed it. Open for alternatives.

The PR also deletes the CSS file and the PHP function `twentytwentyfive_block_stylesheets()`

Closes https://github.com/WordPress/twentytwentyfive/issues/413

**Testing Instructions**

Add two buttons with the outline style variation, one with and one without a background color.
Add links to the buttons.
Hover over the button that does not have a background. Expected: The background color changes slightly.
Hover over the button that has a background color. Expected: The background does not change.
