### PR TITLE
Update Accent 6 color to work better on various backgrounds

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -44,7 +44,7 @@
 					"slug": "accent-5"
 				},
 				{
-					"color": "#11111133",
+					"color": "color-mix(in srgb, currentColor 20%, transparent);",
 					"name": "Accent 6",
 					"slug": "accent-6"
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Replaces the value of accent 6 in the default color palette, to make it work better on dark backgrounds.
Closes https://github.com/WordPress/twentytwentyfive/issues/304

**Screenshots**

https://github.com/user-attachments/assets/6b339320-26c7-4d5c-91ab-a7a739f51027

**Testing Instructions**

Apply the PR and view a template which uses a border, for example the default single post template.
Alternatively place one of the pricing columns pattern and view the column border.