### PR TITLE
Add a 404 template to the right-aligned blog set

### DIFF
--- a/patterns/template-404-vertical-header-blog.php
+++ b/patterns/template-404-vertical-header-blog.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Title: Right-aligned blog, 404
+ * Slug: twentytwentyfive/template-404-vertical-header-blog
+ * Template Types: 404
+ * Viewport width: 1400
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+<!-- wp:columns {"isStackedOnMobile":false,"style":{"spacing":{"padding":{"right":"0","left":"0","top":"0","bottom":"0"},"blockGap":{"left":"0"}}}} -->
+<div class="wp-block-columns is-not-stacked-on-mobile" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+	<!-- wp:column {"width":"8rem"} -->
+	<div class="wp-block-column" style="flex-basis:8rem">
+		<!-- wp:template-part {"slug":"vertical-header"} /-->
+	</div>
+	<!-- /wp:column -->
+	<!-- wp:column {"width":"90%","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"default"}} -->
+	<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50);flex-basis:90%">
+		<!-- wp:group {"tagName":"main","layout":{"type":"default"}} -->
+		<main class="wp-block-group">
+			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+
+			<!-- wp:pattern {"slug":"twentytwentyfive/hidden-404"} /-->
+
+			<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+			<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+		</main>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
+
+<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

<!-- Describe the purpose or reason for the pull request -->
This PR creates a new pattern which uses the vertical header template part and the default hidden-404 in the content section.
The purpose is to make it easier create a site where the header is the same on standard templates.

Closes https://github.com/WordPress/twentytwentyfive/issues/443

**Screenshots**

Selection:
( No idea why the footer is not showing in the preview)
![image](https://github.com/user-attachments/assets/d7bfd6d9-5384-4927-ba17-e396808d58a4)

Front:
![67 local_jkyhkykuykh](https://github.com/user-attachments/assets/24ffca23-08ca-460c-9126-6a4ea43a60b0)


**Testing Instructions**
Go to Editor > Appearance > Templates
Select "Page: 404"
Open the settings sidebar. Select the Templates tab.
Open the Design panel.
Select "Right-aligned blog, 404"
Save
View the 404 on the front of the site.
Confirm that the vertical header is used.
Test that the design looks good on different browser widths.


