### PR TITLE
Add writing-mode to theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -103,6 +103,7 @@
 			]
 		},
 		"typography": {
+			"writingMode": true,
 			"defaultFontSizes": false,
 			"fluid": true,
 			"fontSizes": [


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
The text orientation control is missing in the typography settings for supported, text-based blocks like the site title.
This PR enables the control by setting writingMode to true in theme.json.

Closes https://github.com/WordPress/twentytwentyfive/issues/452

**Screenshots**
With writingMode:
![image](https://github.com/user-attachments/assets/e328937a-fc5a-499c-b2d6-ea4b8866056d)


**Testing Instructions**
Place or select a site title block.
Open the block settings sidebar.
Locate the typography panel:
- You may need to click on the three dot menu in the panel to enable orientation.
