### PR TITLE
Fix: Button focus styles are not visible enough

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1367,9 +1367,7 @@
 				":focus": {
 					"outline": {
 						"color": "var:preset|color|accent-4",
-						"offset": "2px",
-						"style": "dotted",
-						"width": "1px"
+						"offset": "2px"
 					}
 				},
 				":hover": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
The focus outline on the buttons was set to 1px dotted which was not visible enough. See the screenshot in the linked issue.
This PR remove the 1px dotted outline from the button style so that it falls back to the 2px solid outline.

Closes https://github.com/WordPress/twentytwentyfive/issues/439

**Screenshots**
Focus styles  (In Chrome, Windows 11)
![image](https://github.com/user-attachments/assets/d87d1062-9f1f-440b-aa26-656b29dc6d31)

**Testing Instructions**
If your browser does not have focus styles on tabbing enabled, enable it now.

Place a filled button and an outlined button.
Remember to add the links.
Save.
View the buttons on the front of the site.
Place the cursor in the browser address bar and navigate to the buttons using the tab key.
Confirm if you can see when the button is focused.
