### PR TITLE
Fix wide and full width content on the default home, archive and search templates

### DIFF
--- a/patterns/template-query-loop.php
+++ b/patterns/template-query-loop.php
@@ -12,14 +12,14 @@
  */
 
 ?>
-<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"layout":{"type":"default"}} -->
-<div class="wp-block-query">
+<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"align":"full","layout":{"type":"default"}} -->
+<div class="wp-block-query alignfull">
 	<!-- wp:post-template {"align":"full","layout":{"type":"default"}} -->
-		<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"default"}} -->
+		<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 			<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
 			<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
-			<!-- wp:post-content {"align":"full","fontSize":"medium","layout":{"type":"default"}} /-->
+			<!-- wp:post-content {"align":"full","fontSize":"medium","layout":{"type":"constrained"}} /-->
 			<!-- wp:post-date {"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}},"fontSize":"small"} /-->
 		</div>
 		<!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
At some point a regression has happened that cases the full width patterns to only display at content width on the default
home, archive and search templates.

This PR tries to make sure that full and wide content displays correctly. Please see the before and after screenshots.

Closes https://github.com/WordPress/twentytwentyfive/issues/428

**Screenshots**
Please excuse that these images are not taken on the same computer and screen width.

Before:

![home-width](https://github.com/user-attachments/assets/cb3cc94d-c6e1-4e37-8c42-a3f7ff70f346)

![width-test](https://github.com/user-attachments/assets/69d7f778-92fc-48a0-b029-4d3b92c4ccd5)

After:
![67 local_](https://github.com/user-attachments/assets/4b197103-94d3-40f5-9e7a-2f4c1c99ca11)

**Testing Instructions**

Create one or more posts with default, wide and full width content.

There are a couple things to make sure here:
1) The design matches Figma: https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=559-1862&t=s3gLMzojsInRTy1N-4
2) The "Blog" heading aligns with the featured image, post title and **default content width.**
3) Post content that is set to wide align, aligns with header, footer and query pagination.
4) Post content that is set to full width is full width, edge to edge of the browser.
5) The featured image and post title do not touch the edge of the browser on small screen widths. -Confirm that this issue is not happening again: https://github.com/WordPress/twentytwentyfive/issues/345

