### PR TITLE
Fix the block validation error in the link pattern

### DIFF
--- a/patterns/format-link.php
+++ b/patterns/format-link.php
@@ -22,6 +22,7 @@
 		<!-- wp:paragraph -->
 		<p><a href="#">https://example.com</a></p>
 		<!-- /wp:paragraph -->
+		</div>
 	<!-- /wp:group -->
-	</div>
+</div>
 <!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
There is a missing closing `</div>` in the pattern for the link post format.
This PR adds it, to resolve the block validation error

**Testing Instructions**

Place a link post format pattern
Check that there is no block validation error

