### PR TITLE
a letter spacing has magically disappeared #449

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1183,6 +1183,9 @@
 							"textDecoration": "none"
 						}
 					}
+				},
+				"typography": {
+					"letterSpacing": "px"
 				}
 			},
 			"core/quote": {

--- a/theme.json
+++ b/theme.json
@@ -1185,7 +1185,7 @@
 					}
 				},
 				"typography": {
-					"letterSpacing": "px"
+					"letterSpacing": "-.5px"
 				}
 			},
 			"core/quote": {


### PR DESCRIPTION
I have added the missing letter spacing. I don't know what unit is set as the default, so I followed the default value from the core/site-title.
`			"core/post-title": {
				"typography": {
					"letterSpacing": "-.5px"
				}
			},`

Closes: #449