### PR TITLE
Various docblock changes to comply to WP's Docblocks standards

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Twenty Twenty-Five functions and definitions
+ * Twenty Twenty-Five functions and definitions.
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *
@@ -10,48 +10,48 @@
  */
 
 /**
- * Add theme support for post formats.
+ * Adds theme support for post formats.
  */
 if ( ! function_exists( 'twentytwentyfive_post_format_setup' ) ) :
 	/**
-	 * Add theme support for post formats.
+	 * Adds theme support for post formats.
 	 *
 	 * @since Twenty Twenty-Five 1.0
+	 * 
 	 * @return void
 	 */
 	function twentytwentyfive_post_format_setup() {
 		add_theme_support( 'post-formats', array( 'audio', 'gallery', 'image', 'link', 'quote', 'video' ) );
 	}
 endif;
-
 add_action( 'after_setup_theme', 'twentytwentyfive_post_format_setup' );
 
-
 /**
- * Enqueue editor-style.css in the editors.
+ * Enqueues editor-style.css in the editors.
  */
 if ( ! function_exists( 'twentytwentyfive_editor_style' ) ) :
 	/**
-	 * Enqueue editor-style.css in the editors.
+	 * Enqueues editor-style.css in the editors.
 	 *
 	 * @since Twenty Twenty-Five 1.0
+	 * 
 	 * @return void
 	 */
 	function twentytwentyfive_editor_style() {
 		add_editor_style( get_parent_theme_file_uri( 'assets/css/editor-style.css' ) );
 	}
 endif;
-
 add_action( 'after_setup_theme', 'twentytwentyfive_editor_style' );
 
 /**
- * Enqueue style.css on the front.
+ * Enqueues style.css on the front.
  */
 if ( ! function_exists( 'twentytwentyfive_enqueue_styles' ) ) :
 	/**
-	 * Enqueue style.css on the front.
+	 * Enqueues style.css on the front.
 	 *
 	 * @since Twenty Twenty-Five 1.0
+	 * 
 	 * @return void
 	 */
 	function twentytwentyfive_enqueue_styles() {
@@ -63,17 +63,17 @@ if ( ! function_exists( 'twentytwentyfive_enqueue_styles' ) ) :
 		);
 	}
 endif;
-
 add_action( 'wp_enqueue_scripts', 'twentytwentyfive_enqueue_styles' );
 
 /**
- * Register custom block styles.
+ * Registers custom block styles.
  */
 if ( ! function_exists( 'twentytwentyfive_block_styles' ) ) :
 	/**
-	 * Register custom block styles.
+	 * Registers custom block styles.
 	 *
 	 * @since Twenty Twenty-Five 1.0
+	 * 
 	 * @return void
 	 */
 	function twentytwentyfive_block_styles() {
@@ -94,17 +94,17 @@ if ( ! function_exists( 'twentytwentyfive_block_styles' ) ) :
 		);
 	}
 endif;
-
 add_action( 'init', 'twentytwentyfive_block_styles' );
 
 /**
- * Register pattern categories.
+ * Registers pattern categories.
  */
 if ( ! function_exists( 'twentytwentyfive_pattern_categories' ) ) :
 	/**
-	 * Register pattern categories
+	 * Registers pattern categories.
 	 *
 	 * @since Twenty Twenty-Five 1.0
+	 * 
 	 * @return void
 	 */
 	function twentytwentyfive_pattern_categories() {
@@ -126,17 +126,17 @@ if ( ! function_exists( 'twentytwentyfive_pattern_categories' ) ) :
 		);
 	}
 endif;
-
 add_action( 'init', 'twentytwentyfive_pattern_categories' );
 
 /**
- * Register block binding sources.
+ * Registers block binding sources.
  */
 if ( ! function_exists( 'twentytwentyfive_register_block_bindings' ) ) :
 	/**
-	 * Register the copyright block binding source.
+	 * Registers the copyright block binding source.
 	 *
 	 * @since Twenty Twenty-Five 1.0
+	 * 
 	 * @return void
 	 */
 	function twentytwentyfive_register_block_bindings() {
@@ -151,13 +151,14 @@ if ( ! function_exists( 'twentytwentyfive_register_block_bindings' ) ) :
 endif;
 
 /**
- * Register block binding callback function for the copyright.
+ * Registers block binding callback function for the copyright.
  */
 if ( ! function_exists( 'twentytwentyfive_copyright_binding' ) ) :
 	/**
 	 * Callback function for the copyright block binding source.
 	 *
 	 * @since Twenty Twenty-Five 1.0
+	 * 
 	 * @return string Copyright text.
 	 */
 	function twentytwentyfive_copyright_binding() {
@@ -171,5 +172,4 @@ if ( ! function_exists( 'twentytwentyfive_copyright_binding' ) ) :
 		return $copyright_text;
 	}
 endif;
-
 add_action( 'init', 'twentytwentyfive_register_block_bindings' );

--- a/functions.php
+++ b/functions.php
@@ -17,7 +17,7 @@ if ( ! function_exists( 'twentytwentyfive_post_format_setup' ) ) :
 	 * Adds theme support for post formats.
 	 *
 	 * @since Twenty Twenty-Five 1.0
-	 * 
+	 *
 	 * @return void
 	 */
 	function twentytwentyfive_post_format_setup() {
@@ -34,7 +34,7 @@ if ( ! function_exists( 'twentytwentyfive_editor_style' ) ) :
 	 * Enqueues editor-style.css in the editors.
 	 *
 	 * @since Twenty Twenty-Five 1.0
-	 * 
+	 *
 	 * @return void
 	 */
 	function twentytwentyfive_editor_style() {
@@ -51,7 +51,7 @@ if ( ! function_exists( 'twentytwentyfive_enqueue_styles' ) ) :
 	 * Enqueues style.css on the front.
 	 *
 	 * @since Twenty Twenty-Five 1.0
-	 * 
+	 *
 	 * @return void
 	 */
 	function twentytwentyfive_enqueue_styles() {
@@ -73,7 +73,7 @@ if ( ! function_exists( 'twentytwentyfive_block_styles' ) ) :
 	 * Registers custom block styles.
 	 *
 	 * @since Twenty Twenty-Five 1.0
-	 * 
+	 *
 	 * @return void
 	 */
 	function twentytwentyfive_block_styles() {
@@ -104,7 +104,7 @@ if ( ! function_exists( 'twentytwentyfive_pattern_categories' ) ) :
 	 * Registers pattern categories.
 	 *
 	 * @since Twenty Twenty-Five 1.0
-	 * 
+	 *
 	 * @return void
 	 */
 	function twentytwentyfive_pattern_categories() {
@@ -136,7 +136,7 @@ if ( ! function_exists( 'twentytwentyfive_register_block_bindings' ) ) :
 	 * Registers the copyright block binding source.
 	 *
 	 * @since Twenty Twenty-Five 1.0
-	 * 
+	 *
 	 * @return void
 	 */
 	function twentytwentyfive_register_block_bindings() {
@@ -158,7 +158,7 @@ if ( ! function_exists( 'twentytwentyfive_copyright_binding' ) ) :
 	 * Callback function for the copyright block binding source.
 	 *
 	 * @since Twenty Twenty-Five 1.0
-	 * 
+	 *
 	 * @return string Copyright text.
 	 */
 	function twentytwentyfive_copyright_binding() {


### PR DESCRIPTION
**Description**

I suggest to edit a few docblocks for PHP functions to match WP docblock standards.
https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/

**Screenshots**

Not applicable.

**Testing Instructions**

Not applicable.