### PR TITLE
The H1 tag is missing from the shop homepage patterns

### DIFF
--- a/patterns/banner-intro-image.php
+++ b/patterns/banner-intro-image.php
@@ -28,7 +28,7 @@
 		<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} -->
 		<div class="wp-block-column is-vertically-aligned-center">
 			<!-- wp:heading {"level":1,"fontSize":"x-large"} -->
-			<h2 class="wp-block-heading has-x-large-font-size"><?php echo esc_html_x( 'New arrivals', 'Heading for banner with flower', 'twentytwentyfive' ); ?></h2>
+			<h1 class="wp-block-heading has-x-large-font-size"><?php echo esc_html_x( 'New arrivals', 'Heading for banner with flower', 'twentytwentyfive' ); ?></h1>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph -->

--- a/patterns/banner-intro-image.php
+++ b/patterns/banner-intro-image.php
@@ -27,8 +27,8 @@
 
 		<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"blockGap":"var:preset|spacing|40"}}} -->
 		<div class="wp-block-column is-vertically-aligned-center">
-			<!-- wp:heading -->
-			<h2 class="wp-block-heading"><?php echo esc_html_x( 'New arrivals', 'Heading for banner with flower', 'twentytwentyfive' ); ?></h2>
+			<!-- wp:heading {"level":1,"fontSize":"x-large"} -->
+			<h2 class="wp-block-heading has-x-large-font-size"><?php echo esc_html_x( 'New arrivals', 'Heading for banner with flower', 'twentytwentyfive' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph -->


### PR DESCRIPTION
**Description**

The Shop landing page pattern was missing an `h1` tag. I've updated it to use an `h1` instead of an `h2`.

**Screenshots**

No visual changes.

**Testing Instructions**

1. Make sure the theme is active.
2. Create a new page.
3. Select the "Shop Homepage" pattern.
4. Confirm that the top of the pattern ("New arrivals" section) now uses an `h1` instead of an `h2`.

Fixes #369.