### PR TITLE
Fix #465: Tags overlap when extending to two lines

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1156,7 +1156,8 @@
 			"core/post-terms": {
 				"typography": {
 					"fontSize": "var:preset|font-size|small",
-					"fontWeight": "600"
+					"fontWeight": "600",
+					"lineHeight": "2.6"
 				},
 				"elements": {
 					"link": {


### PR DESCRIPTION
**Description**
When the number of tags extend to two lines or more, the pills overlap with the row above/below.

This PR will fix this tags overlapping giving appropriate line height.

**Screenshots**

![Screenshot 2024-09-30 at 16 40 24](https://github.com/user-attachments/assets/dbe09c3a-a633-464f-b2b0-5ddeb3357f79)

**Testing Instructions**

1. Create a new post.
2. Add Title, content and tags.
3. Visit the post and see it on smaller screens.

Closes #465 
