### PR TITLE
Fix #466: Multi-word tags break to multiple lines

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1154,7 +1154,7 @@
 				}
 			},
 			"core/post-terms": {
-				"css": ".wp-block-post-terms a { white-space: nowrap; }",
+				"css": "& a { white-space: nowrap; }",
 				"typography": {
 					"fontSize": "var:preset|font-size|small",
 					"fontWeight": "600"

--- a/theme.json
+++ b/theme.json
@@ -1154,6 +1154,7 @@
 				}
 			},
 			"core/post-terms": {
+				"css": ".wp-block-post-terms a { white-space: nowrap; }",
 				"typography": {
 					"fontSize": "var:preset|font-size|small",
 					"fontWeight": "600"


### PR DESCRIPTION
**Description**
When the tags extend to multiple lines, there is a possibility that the tag at the end of the first row is split between two lines if it is a multi-word tag.

Because the tag is styled like a pill, it appears broken.

This PR will add a property of `no-wrap` for the link tags (pills) that will not break on multiple lines on every screen size.

**Screenshots**
![Screenshot 2024-09-30 at 17 08 47](https://github.com/user-attachments/assets/0b0111e3-e9af-4ca4-b488-93b9583bba6b)

**Testing Instructions**

1. Create a post.
2. Add title, content and multi word tags.
3. Visit the post on various screens.

Closes #466 
