### PR TITLE
Backport comment formatting change

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -9,9 +9,7 @@
  * @since Twenty Twenty-Five 1.0
  */
 
-/**
- * Adds theme support for post formats.
- */
+// Adds theme support for post formats.
 if ( ! function_exists( 'twentytwentyfive_post_format_setup' ) ) :
 	/**
 	 * Adds theme support for post formats.
@@ -26,9 +24,7 @@ if ( ! function_exists( 'twentytwentyfive_post_format_setup' ) ) :
 endif;
 add_action( 'after_setup_theme', 'twentytwentyfive_post_format_setup' );
 
-/**
- * Enqueues editor-style.css in the editors.
- */
+// Enqueues editor-style.css in the editors.
 if ( ! function_exists( 'twentytwentyfive_editor_style' ) ) :
 	/**
 	 * Enqueues editor-style.css in the editors.
@@ -43,9 +39,7 @@ if ( ! function_exists( 'twentytwentyfive_editor_style' ) ) :
 endif;
 add_action( 'after_setup_theme', 'twentytwentyfive_editor_style' );
 
-/**
- * Enqueues style.css on the front.
- */
+// Enqueues style.css on the front.
 if ( ! function_exists( 'twentytwentyfive_enqueue_styles' ) ) :
 	/**
 	 * Enqueues style.css on the front.
@@ -65,9 +59,7 @@ if ( ! function_exists( 'twentytwentyfive_enqueue_styles' ) ) :
 endif;
 add_action( 'wp_enqueue_scripts', 'twentytwentyfive_enqueue_styles' );
 
-/**
- * Registers custom block styles.
- */
+// Registers custom block styles.
 if ( ! function_exists( 'twentytwentyfive_block_styles' ) ) :
 	/**
 	 * Registers custom block styles.
@@ -96,9 +88,7 @@ if ( ! function_exists( 'twentytwentyfive_block_styles' ) ) :
 endif;
 add_action( 'init', 'twentytwentyfive_block_styles' );
 
-/**
- * Registers pattern categories.
- */
+// Registers pattern categories.
 if ( ! function_exists( 'twentytwentyfive_pattern_categories' ) ) :
 	/**
 	 * Registers pattern categories.
@@ -128,9 +118,7 @@ if ( ! function_exists( 'twentytwentyfive_pattern_categories' ) ) :
 endif;
 add_action( 'init', 'twentytwentyfive_pattern_categories' );
 
-/**
- * Registers block binding sources.
- */
+// Registers block binding sources.
 if ( ! function_exists( 'twentytwentyfive_register_block_bindings' ) ) :
 	/**
 	 * Registers the copyright block binding source.
@@ -150,9 +138,7 @@ if ( ! function_exists( 'twentytwentyfive_register_block_bindings' ) ) :
 	}
 endif;
 
-/**
- * Registers block binding callback function for the copyright.
- */
+// Registers block binding callback function for the copyright.
 if ( ! function_exists( 'twentytwentyfive_copyright_binding' ) ) :
 	/**
 	 * Callback function for the copyright block binding source.


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Backport changes already made to the theme in WordPress core:
Use single line comments to follow the PHP coding standards.

Closes https://github.com/WordPress/twentytwentyfive/issues/480

**Testing Instructions**
View the code changes and confirm that the comments have been updated.