### PR TITLE
Landing page patterns: Replace level 1 headings (H1)

### DIFF
--- a/patterns/cta-centered-heading.php
+++ b/patterns/cta-centered-heading.php
@@ -15,10 +15,9 @@
 <div class="wp-block-group alignfull" style="min-height:0vh;padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--40);">
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
-		<!-- wp:heading {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"right":"0","left":"0"},"padding":{"right":"0","left":"0"}}}} -->
-		<h1 class="wp-block-heading has-text-align-center" style="margin-right:0;margin-left:0;padding-right:0;padding-left:0">Tell your story</h1>
+		<!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"right":"0","left":"0"},"padding":{"right":"0","left":"0"}}},"fontSize":"xx-large"} -->
+		<h2 class="wp-block-heading has-text-align-center has-xx-large-font-size" style="margin-right:0;margin-left:0;padding-right:0;padding-left:0">Tell your story</h2>
 		<!-- /wp:heading -->
-
 		<!-- wp:paragraph {"align":"center"} -->
 		<p class="has-text-align-center">Like flowers that bloom in unexpected places, every story unfolds with beauty and resilience, revealing hidden wonders.</p>
 		<!-- /wp:paragraph -->

--- a/patterns/event-rsvp.php
+++ b/patterns/event-rsvp.php
@@ -22,8 +22,8 @@
 		<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--40)">
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 			<div class="wp-block-group">
-				<!-- wp:heading {"level":1} -->
-				<h1 class="wp-block-heading">Stories, historias, iсторії, iστορίες</h1>
+				<!-- wp:heading {"fontSize":"xx-large"} -->
+				<h2 class="wp-block-heading has-xx-large-font-size">Stories, historias, iсторії, iστορίες</h2>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"fontSize":"x-large"} -->

--- a/patterns/page-coming-soon.php
+++ b/patterns/page-coming-soon.php
@@ -20,14 +20,14 @@
 	<div class="wp-block-cover__inner-container">
 		<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
 		<div class="wp-block-group">
-			<!-- wp:heading {"textAlign":"center","level":1,"className":"is-style-text-annotation"} -->
-			<h1 class="wp-block-heading has-text-align-center is-style-text-annotation">Event</h1>
+			<!-- wp:heading {"textAlign":"center","className":"is-style-text-annotation"} -->
+			<h2 class="wp-block-heading has-text-align-center is-style-text-annotation">Event</h2>
 			<!-- /wp:heading -->
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:heading {"textAlign":"center","fontSize":"xx-large"} -->
-		<h2 class="wp-block-heading has-text-align-center has-xx-large-font-size">Something great is coming soon</h2>
+		<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"xx-large"} -->
+		<h3 class="wp-block-heading has-text-align-center has-xx-large-font-size">Something great is coming soon</h3>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center"} -->

--- a/patterns/page-portfolio-home.php
+++ b/patterns/page-portfolio-home.php
@@ -23,8 +23,8 @@
 		<div class="wp-block-columns alignwide" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--50)">
 			<!-- wp:column {"width":"50%"} -->
 			<div class="wp-block-column" style="flex-basis:50%">
-				<!-- wp:heading {"level":1,"align":"wide","fontSize":"x-large"} -->
-				<h1 class="wp-block-heading alignwide has-x-large-font-size">My name is Anna Möller and these are some of my photo projects.</h1>
+				<!-- wp:heading {"align":"wide","fontSize":"x-large"} -->
+				<h2 class="wp-block-heading alignwide has-x-large-font-size">My name is Anna Möller and these are some of my photo projects.</h2>
 				<!-- /wp:heading -->
 			</div>
 			<!-- /wp:column -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This PR replaces the remaining level 1 headings (H1) on the landing page/ coming soon/ portfolio home patterns.
This is because the default page template already has an H1 heading.

Closes https://github.com/WordPress/twentytwentyfive/issues/186

**Testing Instructions**
Add the patterns that are edited in this PR.
Confirm that the H2 heading level is used but that the look is the same: there should not be a visual change to heading font size.
