### PR TITLE
Remove the more posts pattern from the default archive template

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -5,7 +5,6 @@
 	<!-- wp:query-title {"type":"archive"} /-->
 	 <!-- wp:term-description /-->
 	<!-- wp:pattern {"slug":"twentytwentyfive/template-query-loop"} /-->
-	<!-- wp:pattern {"slug":"twentytwentyfive/more-posts"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This PR removes the "more posts" pattern from the default archive template, since it shows the same posts as the main query loop which is the main content of the page. Please see more details in the issue.

Closes https://github.com/WordPress/twentytwentyfive/issues/326
**Screenshots**

**Testing Instructions**
View the default archive template.
Confirm that the "more posts" section below the main content is no longer there.