### PR TITLE
Remove the "media" category from two patterns

### DIFF
--- a/patterns/event-schedule.php
+++ b/patterns/event-schedule.php
@@ -2,7 +2,7 @@
 /**
  * Title: Event schedule
  * Slug: twentytwentyfive/event-schedule
- * Categories: about, media, featured
+ * Categories: about, featured
  * Description: A section with specified dates and times for an event.
  * Keywords: events, agenda, schedule, lectures
  *

--- a/patterns/grid-with-categories.php
+++ b/patterns/grid-with-categories.php
@@ -2,7 +2,7 @@
 /**
  * Title: Grid with categories
  * Slug: twentytwentyfive/grid-with-categories
- * Categories: media, featured
+ * Categories: featured
  * Viewport width: 1400
  * Description: A grid section with different categories.
  *


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Removes the media category from the patterns "Event schedule" and "grid with categories"

Closes https://github.com/WordPress/twentytwentyfive/issues/306

**Testing Instructions**
View the "Media" pattern category in the pattern inserter or under Appearance > Editor > Patterns.
Confirm that these two patterns are not included.
