### PR TITLE
Add links to post dates

### DIFF
--- a/patterns/hidden-sidebar.php
+++ b/patterns/hidden-sidebar.php
@@ -24,8 +24,7 @@
 		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 		<div class="wp-block-group">
 			<!-- wp:post-title {"isLink":true,"fontSize":"medium"} /-->
-
-			<!-- wp:post-date {"fontSize":"small"} /-->
+			<!-- wp:post-date {"fontSize":"small","isLink":true} /-->
 		</div>
 		<!-- /wp:group -->
 

--- a/patterns/template-home-posts-grid-news-blog.php
+++ b/patterns/template-home-posts-grid-news-blog.php
@@ -26,7 +26,7 @@
 				<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40)">
 					<!-- wp:post-title {"textAlign":"center","level":1,"isLink":true,"fontSize":"xx-large"} /-->
 					<!-- wp:post-terms {"term":"category","textAlign":"center","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
-					<!-- wp:post-date {"textAlign":"center"} /-->
+					<!-- wp:post-date {"textAlign":"center","isLink":true} /-->
 				</div>
 				<!-- /wp:group -->
 			<!-- /wp:post-template -->

--- a/patterns/template-home-with-sidebar-news-blog.php
+++ b/patterns/template-home-with-sidebar-news-blog.php
@@ -28,7 +28,7 @@
 					<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
 						<!-- wp:post-title {"level":1,"isLink":true} /-->
 						<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
-						<!-- wp:post-date /-->
+						<!-- wp:post-date {"isLink":true} /-->
 					</div>
 					<!-- /wp:group -->
 				<!-- /wp:post-template -->
@@ -50,7 +50,7 @@
 					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 					<div class="wp-block-group">
 						<!-- wp:post-title {"level":3,"isLink":true,"fontSize":"large"} /-->
-						<!-- wp:post-date {"fontSize":"small"} /-->
+						<!-- wp:post-date {"fontSize":"small","isLink":true} /-->
 					</div>
 					<!-- /wp:group -->
 					<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
@@ -87,7 +87,7 @@
 							<!-- wp:paragraph -->
 							<p>·</p>
 							<!-- /wp:paragraph -->
-							<!-- wp:post-date /-->
+							<!-- wp:post-date {"isLink":true} /-->
 						</div>
 						<!-- /wp:group -->
 					</div>

--- a/patterns/template-query-loop-news-blog.php
+++ b/patterns/template-query-loop-news-blog.php
@@ -14,7 +14,7 @@
 <div class="wp-block-query"><!-- wp:post-template -->
 <!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|50"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}},"border":{"top":{"color":"var:preset|color|accent-6","width":"1px"}}}} -->
 <div class="wp-block-columns" style="border-top-color:var(--wp--preset--color--accent-6);border-top-width:1px;padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:column {"width":"20%"} -->
-<div class="wp-block-column" style="flex-basis:20%"><!-- wp:post-date /--></div>
+<div class="wp-block-column" style="flex-basis:20%"><!-- wp:post-date {"isLink":true} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column -->

--- a/patterns/template-query-loop-vertical-header-blog.php
+++ b/patterns/template-query-loop-vertical-header-blog.php
@@ -16,7 +16,7 @@
 		<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 		<div class="wp-block-group">
 			<!-- wp:post-title {"isLink":true,"fontSize":"xx-large"} /-->
-			<!-- wp:post-date {"fontSize":"small"} /-->
+			<!-- wp:post-date {"fontSize":"small","isLink":true} /-->
 		</div>
 		<!-- /wp:group -->
 		<!-- wp:spacer {"height":"var:preset|spacing|40"} -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This PR adds links to post dates inside query loop blocks.

Why
It is possible to publish posts without titles. When a post without a title is listed in a query loop/post template,
there must be a second link that leads to the blog post, otherwise, there is no way to open the single post.

Looking at the most recent default themes, they have links added to the post date.

Partial for https://github.com/WordPress/twentytwentyfive/issues/288

**Testing Instructions**
Create and publish a post without a title and without a featured image.
Test all home, archive and search templates except for "News blog home". Confirm if you are able to reach the single post from the list of posts.
