### PR TITLE
Multiple templates: Fix underline inconsistencies

### DIFF
--- a/patterns/hidden-written-by.php
+++ b/patterns/hidden-written-by.php
@@ -15,7 +15,7 @@
 	<!-- wp:paragraph -->
 	<p>Written by </p>
 	<!-- /wp:paragraph -->
-	<!-- wp:post-author-name {"isLink":true} /-->
+	<!-- wp:post-author-name {"isLink":true,"style":{"typography":{"textDecoration":"underline"}}} /-->
 	<!-- wp:paragraph -->
 	<p>in</p>
 	<!-- /wp:paragraph -->

--- a/patterns/hidden-written-by.php
+++ b/patterns/hidden-written-by.php
@@ -10,15 +10,15 @@
  */
 
 ?>
-<!-- wp:group {"style":{"spacing":{"blockGap":"0.2em","margin":{"bottom":"var:preset|spacing|60"}}},"fontSize":"small","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group has-small-font-size" style="margin-bottom:var(--wp--preset--spacing--60)">
-	<!-- wp:paragraph {"textColor":"accent-4"} -->
-	<p class="has-accent-4-color has-text-color">Written by </p>
+<!-- wp:group {"style":{"spacing":{"blockGap":"0.2em","margin":{"bottom":"var:preset|spacing|60"}}},"textColor":"accent-4","fontSize":"small","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group has-accent-4-color has-text-color has-link-color has-small-font-size" style="margin-bottom:var(--wp--preset--spacing--60)">
+	<!-- wp:paragraph -->
+	<p>Written by </p>
 	<!-- /wp:paragraph -->
 	<!-- wp:post-author-name {"isLink":true} /-->
-	<!-- wp:paragraph {"textColor":"accent-4"} -->
-	<p class="has-accent-4-color has-text-color">in</p>
+	<!-- wp:paragraph -->
+	<p>in</p>
 	<!-- /wp:paragraph -->
-	<!-- wp:post-terms {"term":"category","style":{"typography":{"fontStyle":"normal","fontWeight":"300"}}} /-->
+	<!-- wp:post-terms {"term":"category","style":{"typography":{"fontWeight":"300","textDecoration":"underline"}}} /-->
 </div>
 <!-- /wp:group -->

--- a/patterns/post-with-left-aligned-content.php
+++ b/patterns/post-with-left-aligned-content.php
@@ -31,7 +31,7 @@
 							<p>by</p>
 							<!-- /wp:paragraph -->
 
-							<!-- wp:post-author-name {"isLink":true,"fontSize":"small"} /-->
+							<!-- wp:post-author-name {"isLink":true,"style":{"typography":{"textDecoration":"underline"}},"fontSize":"small"} /-->
 						</div>
 						<!-- /wp:group -->
 					</div>

--- a/patterns/template-single-news-blog.php
+++ b/patterns/template-single-news-blog.php
@@ -43,8 +43,8 @@
 					<!-- /wp:group -->
 					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 					<div class="wp-block-group">
-						<!-- wp:avatar {"size":30,"style":{"border":{"radius":"100px"}}} /-->
-						<!-- wp:post-author-name {"fontSize":"small"} /-->
+						<!-- wp:avatar {"size":30,"isLink":true,"style":{"border":{"radius":"100px"}}} /-->
+						<!-- wp:post-author-name {"isLink":true,"fontSize":"small"} /-->
 					</div>
 					<!-- /wp:group -->
 				</div>

--- a/patterns/template-single-vertical-header-blog.php
+++ b/patterns/template-single-vertical-header-blog.php
@@ -47,8 +47,8 @@
 				<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)">
 					<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 					<div class="wp-block-group">
-						<!-- wp:avatar {"size":30,"style":{"border":{"radius":"100px"}}} /-->
-						<!-- wp:post-author-name {"fontSize":"small"} /-->
+						<!-- wp:avatar {"size":30,"isLink":true,"style":{"border":{"radius":"100px"}}} /-->
+						<!-- wp:post-author-name {"isLink":true,"fontSize":"small"} /-->
 					</div>
 					<!-- /wp:group -->
 					<!-- wp:post-terms {"term":"post_tag","separator":"  ","className":"is-style-post-terms-1","style":{"typography":{"fontStyle":"normal","fontWeight":"400"}}} /-->

--- a/theme.json
+++ b/theme.json
@@ -1125,6 +1125,20 @@
 					"fontSize": "var:preset|font-size|medium"
 				}
 			},
+			"core/post-author-name": {
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
 			"core/post-date": {
 				"color":{
 					"text": "var:preset|color|accent-4"


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Partial for: https://github.com/WordPress/twentytwentyfive/issues/495

## Default single post template
- Enables the underline typography setting on the terms block, in the markup of the template.
- Moves the color definition from the two paragraphs to the wrapping group block.

**Screenshots**
After: Both links are underlined by default.
![image](https://github.com/user-attachments/assets/07b576db-66a0-4b44-9239-0153ed75e611)

**Testing Instructions**
View the default single post template and confirm if both the author name and category are underlined by default.
Confirm if the heme matches [the design in Figma.](https://www.figma.com/design/dzGCSntVch4EQdVERTqyVK/Twenty-Twenty-Five?node-id=3326-1728&t=GUAp7xV6mAMGjrcI-4)

## Photo blog single post template
By changing the default text decoration on the post author name block to "none", in theme.json, the theme matches Figma.

**Screenshots**
After: the link is not underlined by default.
![image](https://github.com/user-attachments/assets/909ac81d-4d85-458f-8661-4777dad45110)
⚠️  **NOTE: This matches the design, but the link is invisible to sighted users. It is not accessible. The link can only by found by users who will make assumptions and recognize the pattern of the author name and category being linked.

**Testing Instructions**
View the photo blog single post template and confirm that the author name is not underlined by default.

## News blog single post template
The author name and avatar were not linked. The links were added to make the template more consistent with the other templates.

⚠️  To match Figma, no underline was added.  A sighted user will only find the links if they recognize the pattern of the author name being linked (and goes to try it).

![image](https://github.com/user-attachments/assets/5ff2a232-cdf4-4d84-97f9-88714f82de1d)

**Testing Instructions**
View the News blog single post template and confirm that the author name and avatar are linked to the author's user profile.

## Right-aligned blog with vertical header, single post template
The author name and avatar were not linked. The links were added to make the template more consistent with the other templates.

⚠️  To match Figma, no underline was added.  A sighted user will only find the links if they recognize the pattern of the author name being linked (and goes to try it).

![image](https://github.com/user-attachments/assets/4eaabcdc-2a36-41c6-8d03-d642d6ade0c9)

**Testing Instructions**
View the single post template for the right-aligned blog, and confirm that the author name and avatar are linked to the author's user profile.
