### PR TITLE
Replace a dollar sign with euro symbol

### DIFF
--- a/patterns/cta-grid-products-link.php
+++ b/patterns/cta-grid-products-link.php
@@ -55,7 +55,7 @@
 					<!-- /wp:paragraph -->
 
 					<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"2.63rem"}}} -->
-					<p class="has-text-align-center" style="font-size:2.63rem">$30</p>
+					<p class="has-text-align-center" style="font-size:2.63rem">30€</p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:paragraph {"align":"center"} -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This PR updates the "Call to action with grid layout with products and link" pattern to use the euro symbol.
Closes https://github.com/WordPress/twentytwentyfive/issues/493
