### PR TITLE
Requires PHP: remove patch version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Requires at least: 6.7
 Tested up to: 6.7
-Requires PHP: 7.2.24
+Requires PHP: 7.2
 Stable tag: 1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org
 Description: Twenty Twenty-Five emphasizes simplicity and adaptability. It offers flexible design options, supported by a variety of patterns for different page types, such as services and landing pages, making it ideal for building personal blogs, professional portfolios, online magazines, or business websites. Its templates cater to various blog styles, from text-focused to image-heavy layouts. Additionally, it supports international typography and diverse color palettes, ensuring accessibility and customization for users worldwide.
 Requires at least: 6.7
 Tested up to: 6.7
-Requires PHP: 7.2.24
+Requires PHP: 7.2
 Version: 1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
I ran the theme through the Theme Check plugin and got the recommendation to remove the patch version for  the minimum required PHP version.