### PR TITLE
Instagram grid: Update the colors of the cover block

### DIFF
--- a/patterns/media-instagram-grid.php
+++ b/patterns/media-instagram-grid.php
@@ -16,9 +16,9 @@
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","minimumColumnWidth":"18rem"}} -->
 	<div class="wp-block-group alignwide">
-		<!-- wp:cover {"overlayColor":"accent-1","isUserOverlayColor":true,"isDark":false,"style":{"dimensions":{"aspectRatio":"1"}}} -->
-		<div class="wp-block-cover is-light">
-			<span aria-hidden="true" class="wp-block-cover__background has-accent-1-background-color has-background-dim-100 has-background-dim"></span>
+		<!-- wp:cover {"overlayColor":"contrast","isUserOverlayColor":true,"isDark":false,"style":{"dimensions":{"aspectRatio":"1"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"textColor":"base"} -->
+		<div class="wp-block-cover is-light has-base-color has-text-color has-link-color">
+			<span aria-hidden="true" class="wp-block-cover__background has-contrast-background-color has-background-dim-100 has-background-dim"></span>
 			<div class="wp-block-cover__inner-container">
 				<!-- wp:group {"style":{"dimensions":{"minHeight":"100%"},"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical","verticalAlignment":"center","justifyContent":"center"}} -->
 				<div class="wp-block-group" style="min-height:100%"><!-- wp:heading {"fontSize":"large"} -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This PR updates the overlay, text, and link color of the cover block in the "Instagram grid" pattern to
make sure that the color contrast works in all style variations.

The new colors are `base `for the background, and `contrast `for the text and links.
This color combination has a high enough contrast ratio.

Closes https://github.com/WordPress/twentytwentyfive/issues/468

**Screenshots**
![midnight](https://github.com/user-attachments/assets/a15cad8f-7186-44fb-ac1f-74fc552e31b5)
![sunrise](https://github.com/user-attachments/assets/48ee7be5-460e-4373-87eb-b8a671f08117)
![morning](https://github.com/user-attachments/assets/88b1116a-a857-4052-bb24-2d790c06d923)
![twilight](https://github.com/user-attachments/assets/71ef79e6-0761-422d-9253-bce4a5d773a3)
![afternoon](https://github.com/user-attachments/assets/4999f7ae-d11f-444c-80b3-6f20d28ab9f9)
![dusk](https://github.com/user-attachments/assets/85255b1c-763e-4b8b-9d99-75feab1c3a29)
![noon](https://github.com/user-attachments/assets/e76e205b-48bc-4c80-9d53-aeff699d8c16)
![evening](https://github.com/user-attachments/assets/04476c20-17ce-4896-aea7-3f0a121953ce)
![default](https://github.com/user-attachments/assets/de8a7bbc-18bf-47e8-a7ce-3f6b270d932a)



**Testing Instructions**
Insert the Instagram grid pattern
Test the pattern on all style variations.
Confirm that the text and link are readable.

**Note:** Tools like WAVE browser extension are not able to find the correct colors in the automated test, so it will report some errors.



