### PR TITLE
Evening, section style 3: update link color to maintain contrast ratio

### DIFF
--- a/styles/01-evening.json
+++ b/styles/01-evening.json
@@ -131,6 +131,15 @@
 					}
 				}
 			},
+			"section-3": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var:preset|color|contrast"
+						}
+					}
+				}
+			},
 			"section-4": {
 				"elements": {
 					"button": {

--- a/styles/colors/01-evening.json
+++ b/styles/colors/01-evening.json
@@ -101,6 +101,15 @@
 					}
 				}
 			},
+			"section-3": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var:preset|color|contrast"
+						}
+					}
+				}
+			},
 			"section-4": {
 				"elements": {
 					"button": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
While testing, I found that the link color in section style 3 in the "Evening" variation had too low contrast ratio against the background.

This PR updates the link color in this section to be the same as the text color, using the `contrast `color.
The resulting contrast ratio is 4.61:1 which passes WCAG level AA.

![image](https://github.com/user-attachments/assets/f054dec8-fa29-41ca-83b4-a0126a1ee723)


**Testing Instructions**

In the Site Editor, select the evening Style variation.
Insert a group block and apply section style 3.
In the group, insert a paragraph with a link.

Confirm that the link color is readable.
The contrast ratio should be at or above 4.5:1.


