### PR TITLE
Add missing ARIA landmark roles

### DIFF
--- a/patterns/cta-newsletter.php
+++ b/patterns/cta-newsletter.php
@@ -11,8 +11,8 @@
  */
 
 ?>
-<!-- wp:cover {"overlayColor":"accent-1","isUserOverlayColor":true,"minHeight":460,"isDark":false,"metadata":{"categories":["call-to-action"],"patternName":"twentytwentyfive/newsletter-sign-up","name":"Newsletter Sign Up"},"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"800px"}} -->
-<div class="wp-block-cover alignfull is-light" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50);min-height:460px"><span aria-hidden="true" class="wp-block-cover__background has-accent-1-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container">
+<!-- wp:cover {"tagName":"aside","overlayColor":"accent-1","isUserOverlayColor":true,"minHeight":460,"isDark":false,"metadata":{"categories":["call-to-action"],"patternName":"twentytwentyfive/newsletter-sign-up","name":"Newsletter Sign Up"},"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50","top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"800px"}} -->
+<aside class="wp-block-cover alignfull is-light" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50);min-height:460px"><span aria-hidden="true" class="wp-block-cover__background has-accent-1-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container">
 	<!-- wp:heading {"textAlign":"center","fontSize":"xx-large"} -->
 	<h2 class="wp-block-heading has-text-align-center has-xx-large-font-size"><?php esc_html_e( 'Sign up to get daily stories', 'twentytwentyfive' ); ?></h2>
 	<!-- /wp:heading -->
@@ -29,5 +29,6 @@
 	<div class="wp-block-buttons"><!-- wp:button {"textAlign":"center"} -->
 		<div class="wp-block-button"><a class="wp-block-button__link has-text-align-center wp-element-button"><?php esc_html_e( 'Subscribe', 'twentytwentyfive' ); ?></a></div>
 	<!-- /wp:button --></div>
-	<!-- /wp:buttons --></div></div>
+	<!-- /wp:buttons --></div>
+</aside>
 <!-- /wp:cover -->

--- a/patterns/template-single-vertical-header-blog.php
+++ b/patterns/template-single-vertical-header-blog.php
@@ -87,10 +87,10 @@
 			<!-- /wp:group -->
 		</main>
 		<!-- /wp:group -->
-		<!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left"},"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}}}} -->
-		<div class="wp-block-group alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+		<!-- wp:group {"tagName":"aside","align":"wide","layout":{"type":"constrained","justifyContent":"left"},"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}}}} -->
+		<aside class="wp-block-group alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 			<!-- wp:pattern {"slug":"twentytwentyfive/comments"} /-->
-		</div>
+		</aside>
 		<!-- /wp:group -->
 	</div>
 	<!-- /wp:column -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Two templates have blocks that are not inside an ARIA landmark, which is required to pass the accessibility-ready review.
Partial for https://github.com/WordPress/twentytwentyfive/issues/408

In this PR I am not technically adding the `role `attribute, but I am updating two `<div>` elements to `<aside>` which matches
`role="complementary"`. 

See https://make.wordpress.org/themes/handbook/review/accessibility/required/#aria-landmark-roles

In "Right-aligned single post", I am changing the div around the comments area to aside.

In "News blog with featured posts grid", the "Newsletter sign-up" is used between the main and the footer elements.
Instead of adding a new group block to the template I updated the pattern.

**Testing Instructions**
View the two templates.
Confirm that there are no visual changes to the design.
Confirm that the comments area and the newsletter sign-up pattern use the aside element: You can do this by reviewing the code below or using your browser development tools to view the source.
