### PR TITLE
Fix/banner book desc heading

### DIFF
--- a/patterns/banner-about-book.php
+++ b/patterns/banner-about-book.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Title: Banner with book description
  * Slug: twentytwentyfive/banner-about-book
@@ -19,11 +20,11 @@
 		<!-- wp:column {"verticalAlignment":"center","width":""} -->
 		<div class="wp-block-column is-vertically-aligned-center">
 			<!-- wp:heading {"level":3,"className":"wp-block-heading","fontSize":"xx-large"} -->
-			<h3 class="wp-block-heading has-xx-large-font-size"><?php esc_html_e( 'About the book', 'twentytwentyfive' ); ?></h3>
+			<h2 class="wp-block-heading has-xx-large-font-size"><?php esc_html_e('About the book', 'twentytwentyfive'); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"fontSize":"medium"} -->
-			<p class="has-medium-font-size"><?php echo esc_html_x( 'This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist. Fleckenstein&rsquo;s evocative imagery, Strand&rsquo;s groundbreaking modernist approach, and Kōno&rsquo;s meticulous documentation of Japanese life come together in a harmonious blend that celebrates the art of photography. Each image in &ldquo;The Stories Book&rdquo; is accompanied by insightful commentary, providing historical context and revealing the stories behind the photographs. This collection is not only a visual feast but also a tribute to the power of photography to preserve and narrate the multifaceted experiences of humanity.', 'Pattern placeholder text.', 'twentytwentyfive' ); ?></p>
+			<p class="has-medium-font-size"><?php echo esc_html_x('This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist. Fleckenstein&rsquo;s evocative imagery, Strand&rsquo;s groundbreaking modernist approach, and Kōno&rsquo;s meticulous documentation of Japanese life come together in a harmonious blend that celebrates the art of photography. Each image in &ldquo;The Stories Book&rdquo; is accompanied by insightful commentary, providing historical context and revealing the stories behind the photographs. This collection is not only a visual feast but also a tribute to the power of photography to preserve and narrate the multifaceted experiences of humanity.', 'Pattern placeholder text.', 'twentytwentyfive'); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -31,7 +32,7 @@
 		<!-- wp:column {"verticalAlignment":"center","width":"","layout":{"type":"default"}} -->
 		<div class="wp-block-column is-vertically-aligned-center">
 			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
-			<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/book-image-landing.webp" alt="<?php esc_attr_e( 'Image of a book', 'twentytwentyfive' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
+			<figure class="wp-block-image size-full"><img src="<?php echo esc_url(get_template_directory_uri()); ?>/assets/images/book-image-landing.webp" alt="<?php esc_attr_e('Image of a book', 'twentytwentyfive'); ?>" style="aspect-ratio:1;object-fit:cover" /></figure>
 			<!-- /wp:image -->
 		</div>
 		<!-- /wp:column -->

--- a/patterns/banner-about-book.php
+++ b/patterns/banner-about-book.php
@@ -18,7 +18,7 @@
 	<div class="wp-block-columns alignwide">
 		<!-- wp:column {"verticalAlignment":"center","width":""} -->
 		<div class="wp-block-column is-vertically-aligned-center">
-			<!-- wp:heading {"level":2,"className":"wp-block-heading","fontSize":"xx-large"} -->
+			<!-- wp:heading {"className":"wp-block-heading","fontSize":"xx-large"} -->
 			<h2 class="wp-block-heading has-xx-large-font-size"><?php esc_html_e( 'About the book', 'twentytwentyfive' ); ?></h2>
 			<!-- /wp:heading -->
 

--- a/patterns/banner-about-book.php
+++ b/patterns/banner-about-book.php
@@ -19,7 +19,7 @@
 	<div class="wp-block-columns alignwide">
 		<!-- wp:column {"verticalAlignment":"center","width":""} -->
 		<div class="wp-block-column is-vertically-aligned-center">
-			<!-- wp:heading {"level":3,"className":"wp-block-heading","fontSize":"xx-large"} -->
+			<!-- wp:heading {"level":2,"className":"wp-block-heading","fontSize":"xx-large"} -->
 			<h2 class="wp-block-heading has-xx-large-font-size"><?php esc_html_e('About the book', 'twentytwentyfive'); ?></h2>
 			<!-- /wp:heading -->
 

--- a/patterns/banner-about-book.php
+++ b/patterns/banner-about-book.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Title: Banner with book description
  * Slug: twentytwentyfive/banner-about-book
@@ -20,11 +19,11 @@
 		<!-- wp:column {"verticalAlignment":"center","width":""} -->
 		<div class="wp-block-column is-vertically-aligned-center">
 			<!-- wp:heading {"level":2,"className":"wp-block-heading","fontSize":"xx-large"} -->
-			<h2 class="wp-block-heading has-xx-large-font-size"><?php esc_html_e('About the book', 'twentytwentyfive'); ?></h2>
+			<h2 class="wp-block-heading has-xx-large-font-size"><?php esc_html_e( 'About the book', 'twentytwentyfive' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:paragraph {"fontSize":"medium"} -->
-			<p class="has-medium-font-size"><?php echo esc_html_x('This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist. Fleckenstein&rsquo;s evocative imagery, Strand&rsquo;s groundbreaking modernist approach, and Kōno&rsquo;s meticulous documentation of Japanese life come together in a harmonious blend that celebrates the art of photography. Each image in &ldquo;The Stories Book&rdquo; is accompanied by insightful commentary, providing historical context and revealing the stories behind the photographs. This collection is not only a visual feast but also a tribute to the power of photography to preserve and narrate the multifaceted experiences of humanity.', 'Pattern placeholder text.', 'twentytwentyfive'); ?></p>
+			<p class="has-medium-font-size"><?php echo esc_html_x( 'This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist. Fleckenstein&rsquo;s evocative imagery, Strand&rsquo;s groundbreaking modernist approach, and Kōno&rsquo;s meticulous documentation of Japanese life come together in a harmonious blend that celebrates the art of photography. Each image in &ldquo;The Stories Book&rdquo; is accompanied by insightful commentary, providing historical context and revealing the stories behind the photographs. This collection is not only a visual feast but also a tribute to the power of photography to preserve and narrate the multifaceted experiences of humanity.', 'Pattern placeholder text.', 'twentytwentyfive' ); ?></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -32,7 +31,7 @@
 		<!-- wp:column {"verticalAlignment":"center","width":"","layout":{"type":"default"}} -->
 		<div class="wp-block-column is-vertically-aligned-center">
 			<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
-			<figure class="wp-block-image size-full"><img src="<?php echo esc_url(get_template_directory_uri()); ?>/assets/images/book-image-landing.webp" alt="<?php esc_attr_e('Image of a book', 'twentytwentyfive'); ?>" style="aspect-ratio:1;object-fit:cover" /></figure>
+			<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/book-image-landing.webp" alt="<?php esc_attr_e( 'Image of a book', 'twentytwentyfive' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
 			<!-- /wp:image -->
 		</div>
 		<!-- /wp:column -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Pattern uses an H3, creates incorrect heading level a11y error

**Testing Instructions**

1. Add "Banner with book description" pattern to a page
2. Check H2 is used
