### PR TITLE
Midnight: Remove letter spacing from the post title block

### DIFF
--- a/styles/08-midnight.json
+++ b/styles/08-midnight.json
@@ -187,8 +187,7 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontWeight": "200",
-					"letterSpacing": "-2.72px"
+					"fontWeight": "200"
 				}
 			},
 			"core/pullquote": {

--- a/styles/typography/typography-preset-7.json
+++ b/styles/typography/typography-preset-7.json
@@ -84,8 +84,7 @@
 			},
 			"core/post-title": {
 				"typography": {
-					"fontWeight": "200",
-					"letterSpacing": "-2.72px"
+					"fontWeight": "200"
 				}
 			},
 			"core/pullquote": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This PR removes the letter spacing from the post title block for the midnight variation and typography preset 7.
The letter spacing on `elements > heading` was not removed, so the post title falls back to using `letter-spacing: -0.02em;`

Closes https://github.com/WordPress/twentytwentyfive/issues/512

**Screenshots**
After:
<img width="1510" alt="Screenshot of the default single template." src="https://github.com/user-attachments/assets/632134e6-31d6-454c-9bc7-dafb38afe19b">

<img width="1510" alt="Screenshot  of the News blog single post template with sidebar." src="https://github.com/user-attachments/assets/0b7ff7a2-fae4-4db9-95bc-1c866c690438">


**Testing Instructions**
Go to Appearance > Editor > Styles and enable "Midnight".
View the post titles in different parts of the design, and confirm that they are readable.
