### PR TITLE
Fix: More link has incorrect alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -36,3 +36,11 @@ a {
 h1, h2, h3, h4, h5, h6, blockquote, caption, figcaption, p {
 	text-wrap: pretty;
 }
+
+/*
+ * Change the position of the more block on the front, by making it a block level element.
+ * https://github.com/WordPress/gutenberg/issues/65934
+*/
+.more-link {
+	display: block;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

This PR adds CSS to style.css to turn the more link (the more block) into a block level element.
The purpose is to ensure that:
- By default, the block is contained within the default content width, aligning with the rest of the post content.

Closes https://github.com/WordPress/twentytwentyfive/issues/491

**Screenshots**
Before, the more block was all the way to the left:
<img width="1510" alt="Blog home page showing a post with the read more block all the way to the left" src="https://github.com/user-attachments/assets/1f9957cd-d2b8-4dd4-b603-33f74b214ddd">

After, the more block is aligned with the rest of the content
<img width="1510" alt="Blog home page showing a post with the read more block contained within the default width." src="https://github.com/user-attachments/assets/2f5dd919-f21a-46a3-b45c-8570be075fd5">

**Testing Instructions**
Reset any changes you may have made to the blog home template.
Create a new post.
Insert a read more block.
View the post you created in the list of posts, on the blog home template.
Confirm that the block is aligned with the other post content.
