### PR TITLE
Theme.json: Change column block gap to a string

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -977,10 +977,7 @@
 			},
 			"core/columns": {
 				"spacing": {
-					"blockGap": {
-						"left": "var:preset|spacing|50",
-						"top": "var:preset|spacing|50"
-					}
+					"blockGap":"var:preset|spacing|50"
 				}
 			},
 			"core/buttons": {

--- a/theme.json
+++ b/theme.json
@@ -977,7 +977,7 @@
 			},
 			"core/columns": {
 				"spacing": {
-					"blockGap":"var:preset|spacing|50"
+					"blockGap": "var:preset|spacing|50"
 				}
 			},
 			"core/buttons": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This PR changes the columns block gap in theme.json to a string.
The value, spacing preset 50, is unchanged.

Closes https://github.com/WordPress/twentytwentyfive/issues/518

**Testing Instructions**
Confirm that the schema validation in your code editor does not show a warning.
Add a columns block and confirm that the default block spacing is correct.