### PR TITLE
Fix: Remove redundant `fontStyle` and `fontWeight`

### DIFF
--- a/styles/02-noon.json
+++ b/styles/02-noon.json
@@ -101,8 +101,6 @@
 		"typography": {
 			"fontFamily": "var:preset|font-family|literata",
 			"fontSize": "var:preset|font-size|medium",
-			"fontStyle": "normal",
-			"fontWeight": "300",
 			"letterSpacing": "-0.22px",
 			"lineHeight": "1.5"
 		},

--- a/styles/03-dusk.json
+++ b/styles/03-dusk.json
@@ -57,8 +57,6 @@
 		"typography": {
 			"fontFamily": "var:preset|font-family|fira-code",
 			"fontSize": "var:preset|font-size|medium",
-			"fontStyle": "normal",
-			"fontWeight": "300",
 			"letterSpacing": "-0.18px",
 			"lineHeight": "1.5"
 		},

--- a/styles/04-afternoon.json
+++ b/styles/04-afternoon.json
@@ -97,7 +97,6 @@
 	"styles": {
 		"typography": {
 			"fontFamily": "var:preset|font-family|ysabeau-office",
-			"fontStyle": "normal",
 			"fontWeight": "400",
 			"letterSpacing": "-0.22px",
 			"lineHeight": "1.6"
@@ -160,13 +159,11 @@
 			},
 			"core/post-terms": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "400"
 				}
 			},
 			"core/post-title": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "500",
 					"letterSpacing": "-0.8px"
 				}
@@ -180,7 +177,6 @@
 			},
 			"core/quote": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "300"
 				}
 			},

--- a/styles/05-twilight.json
+++ b/styles/05-twilight.json
@@ -88,7 +88,6 @@
 			},
 			"core/post-terms": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "500",
 					"textTransform": "uppercase"
 				}
@@ -123,7 +122,6 @@
 			},
 			"core/site-title": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "500",
 					"letterSpacing": "-0.28px",
 					"lineHeight": "1.3",

--- a/styles/08-midnight.json
+++ b/styles/08-midnight.json
@@ -107,8 +107,6 @@
 	"styles": {
 		"typography": {
 			"fontFamily": "var:preset|font-family|fira-sans",
-			"fontStyle": "normal",
-			"fontWeight": "300",
 			"letterSpacing": "-0.24px",
 			"lineHeight": "1.4"
 		},
@@ -220,7 +218,6 @@
 			},
 			"core/quote": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "300"
 				}
 			},
@@ -263,7 +260,6 @@
 				},
 				"typography": {
 					"fontFamily": "var:preset|font-family|literata",
-					"fontStyle": "normal",
 					"fontWeight": "600",
 					"letterSpacing": "-0.96px",
 					"textTransform": "uppercase"

--- a/styles/typography/typography-preset-1.json
+++ b/styles/typography/typography-preset-1.json
@@ -55,7 +55,6 @@
 		"typography": {
 			"fontFamily": "var:preset|font-family|literata",
 			"fontSize": "var:preset|font-size|medium",
-			"fontWeight": "300",
 			"letterSpacing": "-0.22px",
 			"lineHeight": "1.5"
 		},

--- a/styles/typography/typography-preset-1.json
+++ b/styles/typography/typography-preset-1.json
@@ -55,7 +55,6 @@
 		"typography": {
 			"fontFamily": "var:preset|font-family|literata",
 			"fontSize": "var:preset|font-size|medium",
-			"fontStyle": "normal",
 			"fontWeight": "300",
 			"letterSpacing": "-0.22px",
 			"lineHeight": "1.5"

--- a/styles/typography/typography-preset-2.json
+++ b/styles/typography/typography-preset-2.json
@@ -7,7 +7,6 @@
 		"typography": {
 			"fontFamily": "var:preset|font-family|fira-code",
 			"fontSize": "var:preset|font-size|medium",
-			"fontWeight": "300",
 			"letterSpacing": "-0.18px",
 			"lineHeight": "1.5"
 		},

--- a/styles/typography/typography-preset-2.json
+++ b/styles/typography/typography-preset-2.json
@@ -7,7 +7,6 @@
 		"typography": {
 			"fontFamily": "var:preset|font-family|fira-code",
 			"fontSize": "var:preset|font-size|medium",
-			"fontStyle": "normal",
 			"fontWeight": "300",
 			"letterSpacing": "-0.18px",
 			"lineHeight": "1.5"

--- a/styles/typography/typography-preset-3.json
+++ b/styles/typography/typography-preset-3.json
@@ -54,7 +54,6 @@
 	"styles": {
 		"typography": {
 			"fontFamily": "var:preset|font-family|ysabeau-office",
-			"fontStyle": "normal",
 			"fontWeight": "400",
 			"letterSpacing": "-0.22px",
 			"lineHeight": "1.6"
@@ -92,13 +91,11 @@
 			},
 			"core/post-terms": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "400"
 				}
 			},
 			"core/post-title": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "500",
 					"letterSpacing": "-0.8px"
 				}
@@ -112,7 +109,6 @@
 			},
 			"core/quote": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "300"
 				}
 			},

--- a/styles/typography/typography-preset-4.json
+++ b/styles/typography/typography-preset-4.json
@@ -29,7 +29,6 @@
 			},
 			"core/post-terms": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "500",
 					"textTransform": "uppercase"
 				}
@@ -64,7 +63,6 @@
 			},
 			"core/site-title": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "500",
 					"letterSpacing": "-0.28px",
 					"lineHeight": "1.3",

--- a/styles/typography/typography-preset-7.json
+++ b/styles/typography/typography-preset-7.json
@@ -54,7 +54,6 @@
 	"styles": {
 		"typography": {
 			"fontFamily": "var:preset|font-family|fira-sans",
-			"fontStyle": "normal",
 			"fontWeight": "300",
 			"letterSpacing": "-0.24px",
 			"lineHeight": "1.4"
@@ -97,7 +96,6 @@
 			},
 			"core/quote": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "300"
 				}
 			},

--- a/styles/typography/typography-preset-7.json
+++ b/styles/typography/typography-preset-7.json
@@ -54,7 +54,6 @@
 	"styles": {
 		"typography": {
 			"fontFamily": "var:preset|font-family|fira-sans",
-			"fontWeight": "300",
 			"letterSpacing": "-0.24px",
 			"lineHeight": "1.4"
 		},

--- a/theme.json
+++ b/theme.json
@@ -945,7 +945,6 @@
 		"typography": {
 			"fontFamily": "var:preset|font-family|manrope",
 			"fontSize": "var:preset|font-size|large",
-			"fontStyle": "normal",
 			"fontWeight": "300",
 			"letterSpacing": "-0.1px",
 			"lineHeight": "1.4"
@@ -1024,8 +1023,7 @@
 					}
 				},
 				"typography": {
-					"fontSize": "var:preset|font-size|small",
-					"fontStyle": "normal"
+					"fontSize": "var:preset|font-size|small"
 				},
 				"spacing": {
 					"margin": {
@@ -1252,7 +1250,6 @@
 			"core/pullquote": {
 				"typography": {
 					"fontSize": "var:preset|font-size|xx-large",
-					"fontStyle": "normal",
 					"fontWeight": "300",
 					"lineHeight": "1.2"
 				},
@@ -1444,7 +1441,6 @@
 			},
 			"heading": {
 				"typography": {
-					"fontStyle": "normal",
 					"fontWeight": "400",
 					"lineHeight": "1.125",
 					"letterSpacing": "-0.1px"


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Follow up of https://github.com/WordPress/twentytwentyfive/pull/517#issuecomment-2399304429

- Remove redundant `fontStyle` as the default is normal.
- Remove redundant `fontWeight` from variations that use the same as the one in `theme.json`

**Screenshots**

N/A

**Testing Instructions**

1. Open the site editor
2. Try the following style variations: Noon, Dusk, Afternoon, Twilight, Midnight.
3. Confirm the text styles are the same as before (focus on main text styles, quote, blockquote, post title)
4. Try the following typography presets: "Beiruti & Literata", "Vollkorn & Fira Code", "Platypi & Ysabeau Office", "Roboto Slab & Manrope" and "Literata & Fira Sans"
5. Confirm the text styles are the same as before (focus on main text styles, quote, blockquote, post title)
