### PR TITLE
Fix: Update `Accent 1` color for Midnight variation.

### DIFF
--- a/styles/08-midnight.json
+++ b/styles/08-midnight.json
@@ -26,7 +26,7 @@
 					"slug": "contrast"
 				},
 				{
-					"color": "#4433A6",
+					"color": "#5644BC",
 					"name": "Accent 1",
 					"slug": "accent-1"
 				},

--- a/styles/colors/08-midnight.json
+++ b/styles/colors/08-midnight.json
@@ -16,7 +16,7 @@
 					"slug": "contrast"
 				},
 				{
-					"color": "#4433A6",
+					"color": "#5644BC",
 					"name": "Accent 1",
 					"slug": "accent-1"
 				},


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

<!-- Describe the purpose or reason for the pull request -->

Fixes https://github.com/WordPress/twentytwentyfive/issues/448

Update the `Accent 1` color for Midnight variation to `#5644BC`

**Screenshots**

https://github.com/user-attachments/assets/da897961-faa8-40a0-be29-4d2830e2c260


**Testing Instructions**

1. On the site editor, choose the "Midnight" variation.
2. Create a page.
3. Create a group with the "Style 3" style.
4. Confirm the background is now `#5644BC`
