### PR TITLE
News blog home: Show only one "No results" message.

### DIFF
--- a/patterns/template-home-news-blog.php
+++ b/patterns/template-home-news-blog.php
@@ -16,180 +16,127 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
-		<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|50"}}}} -->
-		<div class="wp-block-columns alignwide">
-			<!-- wp:column {"width":"25%"} -->
-			<div class="wp-block-column" style="flex-basis:25%">
-				<!-- wp:group {"style":{"layout":{"columnSpan":1,"rowSpan":1}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-				<div class="wp-block-group">
-					<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
-					<div class="wp-block-query">
-						<!-- wp:post-template -->
-							<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
-							<div class="wp-block-group">
-								<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
-								<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-								<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
-							</div>
-							<!-- /wp:group -->
-						<!-- /wp:post-template -->
-						<!-- wp:query-no-results -->
-							<!-- wp:paragraph -->
-							<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search.', 'twentytwentyfive' ); ?></p>
-							<!-- /wp:paragraph -->
-						<!-- /wp:query-no-results -->
-					</div>
-					<!-- /wp:query -->
-					<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":"3","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
-					<div class="wp-block-query">
-						<!-- wp:post-template -->
-							<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
-							<div class="wp-block-group">
-								<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
-								<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-								<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
-							</div>
-							<!-- /wp:group -->
-						<!-- /wp:post-template -->
-						<!-- wp:query-no-results -->
-							<!-- wp:paragraph -->
-							<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search.', 'twentytwentyfive' ); ?></p>
-							<!-- /wp:paragraph -->
-						<!-- /wp:query-no-results -->
-					</div>
-					<!-- /wp:query -->
-				</div>
-				<!-- /wp:group -->
-			</div>
-			<!-- /wp:column -->
-			<!-- wp:column {"width":"50%"} -->
-			<div class="wp-block-column" style="flex-basis:50%">
-				<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":"1","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
-				<div class="wp-block-query">
-					<!-- wp:post-template -->
-						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"default"}} -->
-						<div class="wp-block-group">
-							<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"4/3"} /-->
-							<!-- wp:post-title {"level":1,"isLink":true} /-->
-							<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
-							<!-- wp:post-excerpt {"fontSize":"medium"} /-->
-						</div>
-						<!-- /wp:group -->
-					<!-- /wp:post-template -->
-					<!-- wp:query-no-results -->
-						<!-- wp:paragraph -->
-						<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search.', 'twentytwentyfive' ); ?></p>
-						<!-- /wp:paragraph -->
-					<!-- /wp:query-no-results -->
-				</div>
-				<!-- /wp:query -->
-			</div>
-			<!-- /wp:column -->
-			<!-- wp:column {"width":"25%"} -->
-			<div class="wp-block-column" style="flex-basis:25%">
-				<!-- wp:group {"style":{"layout":{"columnSpan":1,"rowSpan":1}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-				<div class="wp-block-group">
-					<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":"2","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
-					<div class="wp-block-query">
-						<!-- wp:post-template -->
-							<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
-							<div class="wp-block-group">
-								<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
-								<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-								<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
-							</div>
-							<!-- /wp:group -->
-						<!-- /wp:post-template -->
-						<!-- wp:query-no-results -->
-							<!-- wp:paragraph -->
-							<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search.', 'twentytwentyfive' ); ?></p>
-							<!-- /wp:paragraph -->
-						<!-- /wp:query-no-results -->
-					</div>
-					<!-- /wp:query -->
-					<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":"4","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
-					<div class="wp-block-query">
-						<!-- wp:post-template -->
-							<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
-							<div class="wp-block-group">
-								<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
-								<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-								<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
-							</div>
-							<!-- /wp:group -->
-						<!-- /wp:post-template -->
-						<!-- wp:query-no-results -->
-							<!-- wp:paragraph -->
-							<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search.', 'twentytwentyfive' ); ?></p>
-							<!-- /wp:paragraph -->
-						<!-- /wp:query-no-results -->
-					</div>
-					<!-- /wp:query -->
-				</div>
-				<!-- /wp:group -->
-			</div>
-			<!-- /wp:column -->
-		</div>
-		<!-- /wp:columns -->
-	</div>
-	<!-- /wp:group -->
-
-	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|50"}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
-		<!-- wp:query {"query":{"perPage":2,"pages":0,"offset":"5","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]},"align":"wide"} -->
-		<div class="wp-block-query alignwide">
-			<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":2}} -->
-				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
-				<div class="wp-block-group">
-					<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
-					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
-					<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
-				</div>
-				<!-- /wp:group -->
-			<!-- /wp:post-template -->
-			<!-- wp:query-no-results -->
-				<!-- wp:paragraph -->
-				<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search.', 'twentytwentyfive' ); ?></p>
-				<!-- /wp:paragraph -->
-			<!-- /wp:query-no-results -->
-		</div>
-		<!-- /wp:query -->
-	</div>
-	<!-- /wp:group -->
 
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
-		<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":"7","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]},"align":"wide"} -->
-		<div class="wp-block-query alignwide">
-			<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":3}} -->
-				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
-				<div class="wp-block-group">
-					<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"4/3"} /-->
-					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-					<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
-				</div>
-				<!-- /wp:group -->
-			<!-- /wp:post-template -->
-			<!-- wp:query-no-results -->
-				<!-- wp:paragraph -->
-				<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search.', 'twentytwentyfive' ); ?></p>
-				<!-- /wp:paragraph -->
-			<!-- /wp:query-no-results -->
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
-				<!-- wp:query-pagination {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-					<!-- wp:query-pagination-previous /-->
-					<!-- wp:query-pagination-numbers /-->
-					<!-- wp:query-pagination-next /-->
-				<!-- /wp:query-pagination -->
-			</div>
-			<!-- /wp:group -->
-		</div>
+	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|50"}}}} -->
+		<div class="wp-block-columns alignwide"><!-- wp:column {"width":"25%"} -->
+		<div class="wp-block-column" style="flex-basis:25%"><!-- wp:group {"style":{"layout":{"columnSpan":1,"rowSpan":1}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+		<div class="wp-block-group"><!-- wp:query {"queryId":26,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
+		<div class="wp-block-query"><!-- wp:post-template -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
+		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
+
+		<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+
+		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
+		<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-no-results -->
+		<!-- wp:paragraph -->
+		<p>Sorry, but nothing was found. Please try a search with different keywords.</p>
+		<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results --></div>
 		<!-- /wp:query -->
-	</div>
+
+		<!-- wp:query {"queryId":27,"query":{"perPage":1,"pages":0,"offset":"3","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
+		<div class="wp-block-query"><!-- wp:post-template -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
+		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
+
+		<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+
+		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
+		<!-- /wp:group -->
+		<!-- /wp:post-template --></div>
+		<!-- /wp:query --></div>
+		<!-- /wp:group --></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"width":"50%"} -->
+		<div class="wp-block-column" style="flex-basis:50%"><!-- wp:query {"queryId":28,"query":{"perPage":1,"pages":0,"offset":"1","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
+		<div class="wp-block-query"><!-- wp:post-template -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"default"}} -->
+		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"4/3"} /-->
+
+		<!-- wp:post-title {"level":1,"isLink":true} /-->
+
+		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
+
+		<!-- wp:post-excerpt {"fontSize":"medium"} /--></div>
+		<!-- /wp:group -->
+		<!-- /wp:post-template --></div>
+		<!-- /wp:query --></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"width":"25%"} -->
+		<div class="wp-block-column" style="flex-basis:25%"><!-- wp:group {"style":{"layout":{"columnSpan":1,"rowSpan":1}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+		<div class="wp-block-group"><!-- wp:query {"queryId":29,"query":{"perPage":1,"pages":0,"offset":"2","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
+		<div class="wp-block-query"><!-- wp:post-template -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
+		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
+
+		<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+
+		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
+		<!-- /wp:group -->
+		<!-- /wp:post-template --></div>
+		<!-- /wp:query -->
+
+		<!-- wp:query {"queryId":30,"query":{"perPage":1,"pages":0,"offset":"4","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
+		<div class="wp-block-query"><!-- wp:post-template -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
+		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
+
+		<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+
+		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
+		<!-- /wp:group -->
+		<!-- /wp:post-template --></div>
+		<!-- /wp:query --></div>
+		<!-- /wp:group --></div>
+		<!-- /wp:column --></div>
+		<!-- /wp:columns --></div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|50"}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:query {"queryId":31,"query":{"perPage":2,"pages":0,"offset":"5","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]},"align":"wide"} -->
+		<div class="wp-block-query alignwide"><!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":2}} -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
+		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
+
+		<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
+
+		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
+		<!-- /wp:group -->
+		<!-- /wp:post-template --></div>
+		<!-- /wp:query --></div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:query {"queryId":32,"query":{"perPage":6,"pages":0,"offset":"7","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]},"align":"wide"} -->
+		<div class="wp-block-query alignwide"><!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":3}} -->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
+		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"4/3"} /-->
+
+		<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+
+		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
+		<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:query-pagination {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+		<!-- wp:query-pagination-previous /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination --></div>
+		<!-- /wp:group --></div>
+		<!-- /wp:query --></div>
 	<!-- /wp:group -->
+
 </main>
 <!-- /wp:group -->
 

--- a/patterns/template-home-news-blog.php
+++ b/patterns/template-home-news-blog.php
@@ -16,127 +16,150 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|50"}}}} -->
-		<div class="wp-block-columns alignwide"><!-- wp:column {"width":"25%"} -->
-		<div class="wp-block-column" style="flex-basis:25%"><!-- wp:group {"style":{"layout":{"columnSpan":1,"rowSpan":1}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-		<div class="wp-block-group"><!-- wp:query {"queryId":26,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
-		<div class="wp-block-query"><!-- wp:post-template -->
-		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
-		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
-
-		<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-
-		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
-		<!-- /wp:group -->
-		<!-- /wp:post-template -->
-
-		<!-- wp:query-no-results -->
-		<!-- wp:paragraph -->
-		<p>Sorry, but nothing was found. Please try a search with different keywords.</p>
-		<!-- /wp:paragraph -->
-		<!-- /wp:query-no-results --></div>
-		<!-- /wp:query -->
-
-		<!-- wp:query {"queryId":27,"query":{"perPage":1,"pages":0,"offset":"3","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
-		<div class="wp-block-query"><!-- wp:post-template -->
-		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
-		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
-
-		<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-
-		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
-		<!-- /wp:group -->
-		<!-- /wp:post-template --></div>
-		<!-- /wp:query --></div>
-		<!-- /wp:group --></div>
-		<!-- /wp:column -->
-
-		<!-- wp:column {"width":"50%"} -->
-		<div class="wp-block-column" style="flex-basis:50%"><!-- wp:query {"queryId":28,"query":{"perPage":1,"pages":0,"offset":"1","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
-		<div class="wp-block-query"><!-- wp:post-template -->
-		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"default"}} -->
-		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"4/3"} /-->
-
-		<!-- wp:post-title {"level":1,"isLink":true} /-->
-
-		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
-
-		<!-- wp:post-excerpt {"fontSize":"medium"} /--></div>
-		<!-- /wp:group -->
-		<!-- /wp:post-template --></div>
-		<!-- /wp:query --></div>
-		<!-- /wp:column -->
-
-		<!-- wp:column {"width":"25%"} -->
-		<div class="wp-block-column" style="flex-basis:25%"><!-- wp:group {"style":{"layout":{"columnSpan":1,"rowSpan":1}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-		<div class="wp-block-group"><!-- wp:query {"queryId":29,"query":{"perPage":1,"pages":0,"offset":"2","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
-		<div class="wp-block-query"><!-- wp:post-template -->
-		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
-		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
-
-		<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-
-		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
-		<!-- /wp:group -->
-		<!-- /wp:post-template --></div>
-		<!-- /wp:query -->
-
-		<!-- wp:query {"queryId":30,"query":{"perPage":1,"pages":0,"offset":"4","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
-		<div class="wp-block-query"><!-- wp:post-template -->
-		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
-		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
-
-		<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-
-		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
-		<!-- /wp:group -->
-		<!-- /wp:post-template --></div>
-		<!-- /wp:query --></div>
-		<!-- /wp:group --></div>
-		<!-- /wp:column --></div>
-		<!-- /wp:columns --></div>
-		<!-- /wp:group -->
-
-		<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|50"}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:query {"queryId":31,"query":{"perPage":2,"pages":0,"offset":"5","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]},"align":"wide"} -->
-		<div class="wp-block-query alignwide"><!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":2}} -->
-		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
-		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
-
-		<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
-
-		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
-		<!-- /wp:group -->
-		<!-- /wp:post-template --></div>
-		<!-- /wp:query --></div>
-		<!-- /wp:group -->
-
-		<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:query {"queryId":32,"query":{"perPage":6,"pages":0,"offset":"7","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]},"align":"wide"} -->
-		<div class="wp-block-query alignwide"><!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":3}} -->
-		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
-		<div class="wp-block-group"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"4/3"} /-->
-
-		<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
-
-		<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /--></div>
-		<!-- /wp:group -->
-		<!-- /wp:post-template -->
-
-		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:query-pagination {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-		<!-- wp:query-pagination-previous /-->
-
-		<!-- wp:query-pagination-numbers /-->
-
-		<!-- wp:query-pagination-next /-->
-		<!-- /wp:query-pagination --></div>
-		<!-- /wp:group --></div>
-		<!-- /wp:query --></div>
+	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|50"}}}} -->
+		<div class="wp-block-columns alignwide">
+			<!-- wp:column {"width":"25%"} -->
+			<div class="wp-block-column" style="flex-basis:25%">
+				<!-- wp:group {"style":{"layout":{"columnSpan":1,"rowSpan":1}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+				<div class="wp-block-group">
+					<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
+					<div class="wp-block-query">
+						<!-- wp:post-template -->
+							<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
+							<div class="wp-block-group">
+								<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
+								<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+								<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
+							</div>
+							<!-- /wp:group -->
+						<!-- /wp:post-template -->
+						<!-- wp:query-no-results -->
+							<!-- wp:paragraph -->
+							<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search.', 'twentytwentyfive' ); ?></p>
+							<!-- /wp:paragraph -->
+						<!-- /wp:query-no-results -->
+					</div>
+					<!-- /wp:query -->
+					<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":"3","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
+					<div class="wp-block-query">
+						<!-- wp:post-template -->
+							<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
+							<div class="wp-block-group">
+								<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
+								<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+								<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
+							</div>
+							<!-- /wp:group -->
+						<!-- /wp:post-template -->
+					</div>
+					<!-- /wp:query -->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:column -->
+			<!-- wp:column {"width":"50%"} -->
+			<div class="wp-block-column" style="flex-basis:50%">
+				<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":"1","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
+				<div class="wp-block-query">
+					<!-- wp:post-template -->
+						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"default"}} -->
+						<div class="wp-block-group">
+							<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"4/3"} /-->
+							<!-- wp:post-title {"level":1,"isLink":true} /-->
+							<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
+							<!-- wp:post-excerpt {"fontSize":"medium"} /-->
+						</div>
+						<!-- /wp:group -->
+					<!-- /wp:post-template -->
+				</div>
+				<!-- /wp:query -->
+			</div>
+			<!-- /wp:column -->
+			<!-- wp:column {"width":"25%"} -->
+			<div class="wp-block-column" style="flex-basis:25%">
+				<!-- wp:group {"style":{"layout":{"columnSpan":1,"rowSpan":1}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+				<div class="wp-block-group">
+					<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":"2","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
+					<div class="wp-block-query">
+						<!-- wp:post-template -->
+							<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
+							<div class="wp-block-group">
+								<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
+								<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+								<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
+							</div>
+							<!-- /wp:group -->
+						<!-- /wp:post-template -->
+					</div>
+					<!-- /wp:query -->
+					<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":"4","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]}} -->
+					<div class="wp-block-query">
+						<!-- wp:post-template -->
+							<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
+							<div class="wp-block-group">
+								<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
+								<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+								<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
+							</div>
+							<!-- /wp:group -->
+						<!-- /wp:post-template -->
+					</div>
+					<!-- /wp:query -->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:column -->
+		</div>
+		<!-- /wp:columns -->
+	</div>
 	<!-- /wp:group -->
 
+	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|50"}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:query {"query":{"perPage":2,"pages":0,"offset":"5","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]},"align":"wide"} -->
+		<div class="wp-block-query alignwide">
+			<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":2}} -->
+				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
+				<div class="wp-block-group">
+					<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
+					<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
+				</div>
+				<!-- /wp:group -->
+			<!-- /wp:post-template -->
+		</div>
+		<!-- /wp:query -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":"7","postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]},"align":"wide"} -->
+		<div class="wp-block-query alignwide">
+			<!-- wp:post-template {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","columnCount":3}} -->
+				<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
+				<div class="wp-block-group">
+					<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"4/3"} /-->
+					<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+					<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
+				</div>
+				<!-- /wp:group -->
+			<!-- /wp:post-template -->
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
+				<!-- wp:query-pagination {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+					<!-- wp:query-pagination-previous /-->
+					<!-- wp:query-pagination-numbers /-->
+					<!-- wp:query-pagination-next /-->
+				<!-- /wp:query-pagination -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:query -->
+	</div>
+	<!-- /wp:group -->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
**Description**

The News blog home has a lot of "No results found" messages. 

![before](https://github.com/user-attachments/assets/e776867b-58e4-4a5b-9b79-24367f65592f)

Those are blocks that exist to let you visually style the appearance of the same "no results" message on the frontend, for a particular loop. The duplicated messages, especially in the editor with few posts, where you'd see even more results from the query block itself, is arguably a buggy experience.

What's unique about the News blog home template, is that it uses multiple query loops with _offsets_, to create a full news homepage. The multiple loops exist to have several columns, and the offsets exist to still visually make it appear as a single feed. That last part is improtant: the goal of this page is not for a reader to think of this page as _multiple feeds of content_, but as a _single feed of content_. If it was the former, the offsets would not have been used.

Because of the goal of having a single feed of content, it seems reasonable to also only have a single "No results found" block on the page. It reads as a bug, both for an editor and a reader, to see multiple "No results found" messages. To that end, this PR removes all but one "No results" block, the one that remains is in the first loop.

![after](https://github.com/user-attachments/assets/414fdf1a-a249-41d7-9102-385de799f1b7)

The argument being: if there's a single post in the first loop, then there's content, results were found. If there's not even a single post, no content was found, then, show the message.

Sharing for your quick thoughts first, though this will likely need better indentation than I've provided in this first push.

**Testing Instructions**

* Open the blog home template in the site editor.
* Click "Design" in the inspector, select "News blog home".
* Observe only a single "No results" block in the first query loop.