### PR TITLE
Fix: Replace empty paragraph with spacer.

### DIFF
--- a/patterns/page-link-in-bio-heading-paragraph-links-image.php
+++ b/patterns/page-link-in-bio-heading-paragraph-links-image.php
@@ -55,9 +55,9 @@
 			<!-- wp:cover {"url":"<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/link-in-bio-background.webp","alt":"Photo of a woman worker.","dimRatio":0,"customOverlayColor":"#6b6b6b","isUserOverlayColor":true,"minHeight":100,"minHeightUnit":"vh","layout":{"type":"default"}} -->
 			<div class="wp-block-cover" style="min-height:100vh"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim" style="background-color:#6b6b6b"></span>
 				<img class="wp-block-cover__image-background" alt="<?php esc_attr_e( 'Photo of a woman worker.', 'twentytwentyfive' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/link-in-bio-background.webp" data-object-fit="cover"/><div class="wp-block-cover__inner-container">
-				<!-- wp:paragraph {"align":"center","fontSize":"large"} -->
-				<p class="has-text-align-center has-large-font-size"></p>
-				<!-- /wp:paragraph -->
+				<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
+				<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
 			</div></div>
 			<!-- /wp:cover -->
 		</div>

--- a/patterns/page-link-in-bio-with-tight-margins.php
+++ b/patterns/page-link-in-bio-with-tight-margins.php
@@ -26,9 +26,9 @@
 				<span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim" style="background-color:#818181"></span>
 				<img class="wp-block-cover__image-background" alt="<?php esc_attr_e( 'Black and white photo focusing on a woman and a child from afar.', 'twentytwentyfive' ); ?>" src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/link-in-bio-image.webp" data-object-fit="cover"/><div class="wp-block-cover__inner-container">
 
-				<!-- wp:paragraph {"align":"center","fontSize":"large"} -->
-				<p class="has-text-align-center has-large-font-size"></p>
-				<!-- /wp:paragraph -->
+				<!-- wp:spacer {"height":"var:preset|spacing|20"} -->
+				<div style="height:var(--wp--preset--spacing--20)" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
 			</div></div>
 			<!-- /wp:cover -->
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

<!-- Describe the purpose or reason for the pull request -->
Replace empty paragraph with spacer in cover blocks, so that the patterns have a better presentation in the editor.

| Before | After | 
| --- | --- |
| <img width="1358" alt="Screenshot 2024-10-09 at 11 07 09" src="https://github.com/user-attachments/assets/5c9bebf6-e1d8-4c3f-b0d9-795ff7c90445"> | <img width="1359" alt="Screenshot 2024-10-09 at 11 08 30" src="https://github.com/user-attachments/assets/4bb1d918-90cb-4a38-aff1-d221c32858f3"> |
| <img width="1710" alt="Screenshot 2024-10-09 at 11 05 27" src="https://github.com/user-attachments/assets/d15f7735-dfa7-42ba-9fdb-faf6825c4330"> | <img width="1708" alt="Screenshot 2024-10-09 at 11 04 09" src="https://github.com/user-attachments/assets/8aadcb61-fba4-4381-a014-f8f0d810feae"> |


**Testing Instructions**

1. Create a page.
2. Insert the following patterns: "Link in bio heading, paragraph, links and full-height image" and "Link in bio with tight margins"
3. Confirm there's no "Type / to choose a block" text in the images.
