### PR TITLE
Try: Clean up posts patterns

### DIFF
--- a/patterns/page-business-home.php
+++ b/patterns/page-business-home.php
@@ -2,7 +2,7 @@
 /**
  * Title: Business homepage
  * Slug: twentytwentyfive/page-business-home
- * Categories: twentytwentyfive_page, posts, featured
+ * Categories: twentytwentyfive_page, featured
  * Keywords: starter
  * Block Types: core/post-content
  * Post Types: page, wp_template

--- a/patterns/page-shop-home.php
+++ b/patterns/page-shop-home.php
@@ -2,7 +2,7 @@
 /**
  * Title: Shop homepage
  * Slug: twentytwentyfive/page-shop-home
- * Categories: twentytwentyfive_page, posts, featured
+ * Categories: twentytwentyfive_page, featured
  * Keywords: starter
  * Block Types: core/post-content
  * Post Types: page, wp_template

--- a/patterns/template-query-loop-photo-blog.php
+++ b/patterns/template-query-loop-photo-blog.php
@@ -4,6 +4,7 @@
  * Slug: twentytwentyfive/template-query-loop-photo-blog
  * Categories: query
  * Block Types: core/query
+ * Viewport width: 1400
  * Description: A list of posts, 3 columns, with only featured images.
  *
  * @package WordPress


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

<!-- Describe the purpose or reason for the pull request -->
Try for https://github.com/WordPress/twentytwentyfive/issues/411

- Remove "Business homepage" from that list.
- Remove "Shop homepage" from that list.
- Improve the way the "Photo blog posts" is displayed there. It is a query loop block without side spacing, that's why there no gap to the sides.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->


https://github.com/user-attachments/assets/e09c44fa-6170-4a1a-a410-6f3f39757353



**Testing Instructions**

1. Create a page.
2. Open the inserter
3. Go to patterns
4. Go to "Posts"
5. Confirm that the homepages are not there and that the "Photo blog posts" shows three columns.
