### PR TITLE
Try/element styles

### DIFF
--- a/assets/css/editor-style.css
+++ b/assets/css/editor-style.css
@@ -6,3 +6,22 @@ a {
 	text-decoration-thickness: 1px !important;
 	text-underline-offset: .1em;
 }
+
+/*
+ * Form elements
+*/
+:where(textarea),
+:where(select),
+:where(input:not([type="submit"])) {
+	border: 1px solid;
+	font-size: 1em;
+	font-family: inherit;
+	border-radius: .25rem;
+	border-color: var(--wp--preset--color--accent-6);
+}
+
+:where(textarea),
+:where(select),
+:where(input:not([type="submit"]):not([type="checkbox"])) {
+	padding: 0.667rem;
+}

--- a/style.css
+++ b/style.css
@@ -44,3 +44,26 @@ h1, h2, h3, h4, h5, h6, blockquote, caption, figcaption, p {
 .more-link {
 	display: block;
 }
+
+/*
+ * Form elements
+*/
+:where(textarea),
+:where(select),
+:where(input:not([type="submit"])) {
+	border: 1px solid;
+	font-size: 1em;
+	font-family: inherit;
+	border-radius: .25rem;
+	border-color: var(--wp--preset--color--accent-6);
+}
+
+:where(textarea),
+:where(select),
+:where(input:not([type="submit"]):not([type="checkbox"])) {
+	padding: 0.667rem;
+}
+
+:where(textarea) {
+	width: 100%;
+}

--- a/styles/02-noon.json
+++ b/styles/02-noon.json
@@ -245,6 +245,24 @@
 					"fontWeight": "300"
 				}
 			},
+			"core/search": {
+				"typography": {
+					"fontFamily": "var:preset|font-family|beiruti"
+				},
+				"elements": {
+					"button": {
+						"shadow": "var:preset|shadow|natural",
+						"spacing": {
+							"padding": {
+								"bottom": "0.6rem",
+								"left": "1.6rem",
+								"right": "1.6rem",
+								"top": "0.6rem"
+							}
+						}
+					}
+				}
+			},
 			"core/site-tagline": {
 				"typography": {
 					"fontSize": "var:preset|font-size|small"

--- a/styles/03-dusk.json
+++ b/styles/03-dusk.json
@@ -169,6 +169,16 @@
 					"letterSpacing": "-0.18px"
 				}
 			},
+			"core/search": {
+				"css": "& .wp-block-search__input{border-radius:4px;border-color:var(--wp--preset--color--accent-6);}",
+				"elements": {
+					"button": {
+						"border": {
+							"radius": "4px"
+						}
+					}
+				}
+			},
 			"core/site-title": {
 				"color": {
 					"text": "var:preset|color|accent-3"

--- a/styles/04-afternoon.json
+++ b/styles/04-afternoon.json
@@ -184,6 +184,16 @@
 					"fontWeight": "300"
 				}
 			},
+			"core/search": {
+				"css": "& .wp-block-search__input{border-radius:0px;border-color:var(--wp--preset--color--accent-6);}",
+				"elements": {
+					"button": {
+						"border": {
+							"radius": "0px"
+						}
+					}
+				}
+			},
 			"core/site-title": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|ysabeau-office",

--- a/styles/06-morning.json
+++ b/styles/06-morning.json
@@ -185,6 +185,16 @@
 					"fontWeight": "900"
 				}
 			},
+			"core/search": {
+				"css": "& .wp-block-search__input{border-radius:0px;border-color:var(--wp--preset--color--accent-6);}",
+				"elements": {
+					"button": {
+						"border": {
+							"radius": "0px"
+						}
+					}
+				}
+			},
 			"core/site-title": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|ysabeau-office",

--- a/styles/07-sunrise.json
+++ b/styles/07-sunrise.json
@@ -175,6 +175,16 @@
 					}
 				}
 			},
+			"core/search": {
+				"css": "& .wp-block-search__input{border-radius:0px;border-color:var(--wp--preset--color--accent-6);}",
+				"elements": {
+					"button": {
+						"border": {
+							"radius": "0px"
+						}
+					}
+				}
+			},
 			"core/site-title": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|platypi",

--- a/styles/08-midnight.json
+++ b/styles/08-midnight.json
@@ -225,8 +225,13 @@
 				}
 			},
 			"core/search": {
-				"border": {
-					"radius": "0px"
+				"css": "& .wp-block-search__input{border-radius:0px;border-color:var(--wp--preset--color--accent-6);}",
+				"elements": {
+					"button": {
+						"border": {
+							"radius": "0px"
+						}
+					}
 				}
 			},
 			"core/site-logo": {

--- a/styles/typography/typography-preset-1.json
+++ b/styles/typography/typography-preset-1.json
@@ -123,6 +123,11 @@
 					"fontWeight": "300"
 				}
 			},
+			"core/search": {
+				"typography": {
+					"fontFamily": "var:preset|font-family|beiruti"
+				}
+			},
 			"core/site-tagline": {
 				"typography": {
 					"fontSize": "var:preset|font-size|small"


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Experimental alternative to https://github.com/WordPress/twentytwentyfive/pull/525

The biggest issue with the CSS in this PR is that it affects some inputs in the editor canvas.
For example, the RSS block has an input field which is affected by the padding in the theme editor stylesheet, and this must be prevented.

How can it be prevented, but at the same time ensure that elements in third party plugins are not unstyled, but that the plugins can override the styles? I don't think there is a safe way to target these elements with this generic CSS.

**Screenshots**
**Before:** This is the HTML block with the fake form in the Dusk style variation:
<img width="280" alt="Unstyled form inputs" src="https://github.com/user-attachments/assets/77067011-e807-4d0a-8be1-9562ebc0ac41">

After:
<img width="736" alt="Styled from inputs" src="https://github.com/user-attachments/assets/6e08c905-145d-4043-8362-e4d180cdfe84">



**Testing Instructions**
Create a new post.
Add an RSS block.
Add the following limited sample content:
```
<!-- wp:html -->
<form>
<input type="text"></br></br>
<input type="search" placeholder="Search placeholder"></br></br>
<select>
<option>Hello</option>
<option>World</option>
</select></br></br>
<input type="checkbox"></br></br>
<textarea>Textarea</textarea>
</form>
<!-- /wp:html -->
```

Preview other parts of the editor UI to find other elements that may be affected by the theme editor styles.


