### PR TITLE
Update submenu and overlay color of the header navigation

### DIFF
--- a/patterns/header-centered.php
+++ b/patterns/header-centered.php
@@ -19,7 +19,7 @@
 		<!-- wp:site-title {"level":0,"textAlign":"center","align":"wide","fontSize":"x-large"} /-->
 		<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 		<div class="wp-block-group alignwide">
-			<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"center"}} /-->
+			<!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"center"}} /-->
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/patterns/header-columns.php
+++ b/patterns/header-columns.php
@@ -24,7 +24,7 @@
 		<!-- /wp:group -->
 		<!-- wp:group {"layout":{"type":"constrained","justifyContent":"left"}} -->
 		<div class="wp-block-group">
-			<!-- wp:navigation {"layout":{"type":"flex","orientation":"vertical"}} /-->
+			<!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","orientation":"vertical"}} /-->
 		</div>
 		<!-- /wp:group -->
 		<!-- wp:site-logo /-->

--- a/patterns/header-large-title.php
+++ b/patterns/header-large-title.php
@@ -19,7 +19,7 @@
 		<!-- wp:site-title {"level":0,"style":{"typography":{"fontSize":"100px","lineHeight":"1.2"}}} /-->
 		<!-- wp:group {"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group" style="padding-right:0;padding-left:0">
-			<!-- wp:navigation {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","justifyContent":"right","orientation":"vertical"}} /-->
+			<!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","justifyContent":"right","orientation":"vertical"}} /-->
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/patterns/header.php
+++ b/patterns/header.php
@@ -21,7 +21,7 @@
 			<!-- wp:site-title {"level":0} /-->
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
 			<div class="wp-block-group">
-				<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right","flexWrap":"wrap"}} /-->
+				<!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"right","flexWrap":"wrap"}} /-->
 			</div>
 			<!-- /wp:group -->
 		</div>

--- a/patterns/vertical-header.php
+++ b/patterns/vertical-header.php
@@ -18,7 +18,7 @@
 	<div class="wp-block-group alignwide" style="min-height:100vh;">
 		<!-- wp:group {"align":"full","layout":{"type":"flex","orientation":"vertical","justifyContent":"center","verticalAlignment":"center"}} -->
 		<div class="wp-block-group alignfull">
-			<!-- wp:navigation {"overlayMenu":"always","style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}},"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal","flexWrap":"wrap"}} /-->
+			<!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","overlayMenu":"always","style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}},"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal","flexWrap":"wrap"}} /-->
 			<!-- wp:site-title {"level":0,"style":{"typography":{"writingMode":"vertical-rl"}},"fontSize":"large"} /-->
 		</div>
 		<!-- /wp:group -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

This PR adjusts the submenu and overlay text and background colors for the navigation block in the header patterns.
Note that I did not update other patterns like the footers, because they have the overlay turned off by default.

Closes https://github.com/WordPress/twentytwentyfive/issues/533

**Screenshots**
I only recorded the default header. After:

https://github.com/user-attachments/assets/889d7f70-2322-423c-bb84-9b835979c97f

**Testing Instructions**

Preview all the headers in the theme and confirm that:
The submenu in the navigation block does not have a white background color (unless white is part of the palette).
The overlay  or "mobile menu" does not have white background (unless white is part of the palette).

1) Add a few menu items to the main navigation block, including a submenu.
2) Go to Appearance > Editor and select any template to edit.
3) Click on the "View" icon and select mobile.
4) Click on the menu button on the navigation block to enable the mobile menu.
5) Now open the Styles sidebar.
6) Open "Browse styles" and test the different style variations.
7) Change the header template part, and repeat.
