### PR TITLE
List block: polish spacing between indented items

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1364,7 +1364,7 @@
 				}
 			},
 			"core/list": {
-				"css": "& li{margin-bottom: 0.5rem;}"
+				"css": "& li{margin-top: 0.5rem;}"
 			}
 		},
 		"elements": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Updates the margin between the list items in theme.json.
Closes https://github.com/WordPress/twentytwentyfive/issues/531

**Screenshots**
![image](https://github.com/user-attachments/assets/aedd65dc-79b5-483c-841a-3aa9657ccf08)

![image](https://github.com/user-attachments/assets/146916a6-1721-488d-8fad-9752acb80a30)

**Testing Instructions**
Add three list blocks with some indented items: Test both ordered, unordered, and the checkmark style.
Confirm that the spacing is even and sufficient.
