### PR TITLE
Update Twilight and typography preset 4

### DIFF
--- a/styles/05-twilight.json
+++ b/styles/05-twilight.json
@@ -46,13 +46,57 @@
 					"slug": "accent-6"
 				}
 			]
+		},
+		"typography": {
+			"fontSizes": [
+				{
+					"fluid": false,
+					"name": "Small",
+					"size": "0.875rem",
+					"slug": "small"
+				},
+				{
+					"fluid": {
+						"max": "1.125rem",
+						"min": "1rem"
+					},
+					"name": "Medium",
+					"size": "1rem",
+					"slug": "medium"
+				},
+				{
+					"fluid": {
+						"max": "1.375rem",
+						"min": "1.125rem"
+					},
+					"name": "Large",
+					"size": "1.38rem",
+					"slug": "large"
+				},
+				{
+					"fluid": {
+						"max": "2rem",
+						"min": "1.75rem"
+					},
+					"name": "Extra Large",
+					"size": "1.75rem",
+					"slug": "x-large"
+				},
+				{
+					"fluid": {
+						"max": "2.4rem",
+						"min": "2.15rem"
+					},
+					"name": "Extra Extra Large",
+					"size": "2.15rem",
+					"slug": "xx-large"
+				}
+			]
 		}
 	},
 	"styles": {
 		"typography": {
-			"fontWeight": "500",
-			"lineHeight": "1.3",
-			"letterSpacing": "-0.22px"
+			"letterSpacing": "0"
 		},
 		"blocks": {
 			"core/button": {
@@ -86,28 +130,11 @@
 					"fontSize": "var:preset|font-size|small"
 				}
 			},
-			"core/post-terms": {
-				"typography": {
-					"fontWeight": "500",
-					"textTransform": "uppercase"
-				}
-			},
-			"core/post-title": {
-				"typography": {
-					"fontWeight": "200",
-					"letterSpacing": "-2.32px"
-				}
-			},
 			"core/pullquote": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|roboto-slab",
-					"fontSize": "var:preset|font-size|x-large",
+					"fontSize": "var:preset|font-size|xx-large",
 					"fontWeight": "200"
-				}
-			},
-			"core/query-title": {
-				"typography": {
-					"fontWeight": "300"
 				}
 			},
 			"core/search": {
@@ -118,14 +145,6 @@
 			"core/site-tagline": {
 				"typography": {
 					"fontSize": "var:preset|font-size|large"
-				}
-			},
-			"core/site-title": {
-				"typography": {
-					"fontWeight": "500",
-					"letterSpacing": "-0.28px",
-					"lineHeight": "1.3",
-					"textTransform": "uppercase"
 				}
 			}
 		},
@@ -151,22 +170,10 @@
 					"letterSpacing": "-0.5px"
 				}
 			},
-			"h5": {
-				"typography": {
-					"fontWeight": "400",
-					"letterSpacing": "0px"
-				}
-			},
-			"h6": {
-				"typography": {
-					"fontWeight": "400",
-					"letterSpacing": "1px"
-				}
-			},
 			"heading": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|roboto-slab",
-					"fontWeight": "200",
+					"fontWeight": "300",
 					"letterSpacing": "-0.5px",
 					"lineHeight": "1.2"
 				}

--- a/styles/05-twilight.json
+++ b/styles/05-twilight.json
@@ -146,6 +146,11 @@
 				"typography": {
 					"fontSize": "var:preset|font-size|large"
 				}
+			},
+			"core/post-terms": {
+				"typography": {
+					"fontWeight": "500"
+				}
 			}
 		},
 		"elements": {

--- a/styles/05-twilight.json
+++ b/styles/05-twilight.json
@@ -130,6 +130,11 @@
 					"fontSize": "var:preset|font-size|small"
 				}
 			},
+			"core/post-terms": {
+				"typography": {
+					"fontWeight": "500"
+				}
+			},
 			"core/pullquote": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|roboto-slab",
@@ -147,9 +152,9 @@
 					"fontSize": "var:preset|font-size|large"
 				}
 			},
-			"core/post-terms": {
+			"core/site-title": {
 				"typography": {
-					"fontWeight": "500"
+					"textTransform": "uppercase"
 				}
 			}
 		},

--- a/styles/05-twilight.json
+++ b/styles/05-twilight.json
@@ -169,12 +169,6 @@
 					"textTransform": "uppercase"
 				}
 			},
-			"h4": {
-				"typography": {
-					"fontWeight": "300",
-					"letterSpacing": "-0.5px"
-				}
-			},
 			"heading": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|roboto-slab",

--- a/styles/typography/typography-preset-4.json
+++ b/styles/typography/typography-preset-4.json
@@ -104,12 +104,6 @@
 					"textTransform": "uppercase"
 				}
 			},
-			"h4": {
-				"typography": {
-					"fontWeight": "300",
-					"letterSpacing": "-0.5px"
-				}
-			},
 			"heading": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|roboto-slab",

--- a/styles/typography/typography-preset-4.json
+++ b/styles/typography/typography-preset-4.json
@@ -89,6 +89,11 @@
 				"typography": {
 					"fontSize": "var:preset|font-size|large"
 				}
+			},
+			"core/post-terms": {
+				"typography": {
+					"fontWeight": "500"
+				}
 			}
 		},
 		"elements": {

--- a/styles/typography/typography-preset-4.json
+++ b/styles/typography/typography-preset-4.json
@@ -3,11 +3,57 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Roboto Slab & Manrope",
 	"slug": "typography-preset-4",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"fluid": false,
+					"name": "Small",
+					"size": "0.875rem",
+					"slug": "small"
+				},
+				{
+					"fluid": {
+						"max": "1.125rem",
+						"min": "1rem"
+					},
+					"name": "Medium",
+					"size": "1rem",
+					"slug": "medium"
+				},
+				{
+					"fluid": {
+						"max": "1.375rem",
+						"min": "1.125rem"
+					},
+					"name": "Large",
+					"size": "1.38rem",
+					"slug": "large"
+				},
+				{
+					"fluid": {
+						"max": "2rem",
+						"min": "1.75rem"
+					},
+					"name": "Extra Large",
+					"size": "1.75rem",
+					"slug": "x-large"
+				},
+				{
+					"fluid": {
+						"max": "2.4rem",
+						"min": "2.15rem"
+					},
+					"name": "Extra Extra Large",
+					"size": "2.15rem",
+					"slug": "xx-large"
+				}
+			]
+		}
+	},
 	"styles": {
 		"typography": {
-			"fontWeight": "500",
-			"lineHeight": "1.3",
-			"letterSpacing": "-0.22px"
+			"letterSpacing": "0"
 		},
 		"blocks": {
 			"core/navigation": {
@@ -27,28 +73,11 @@
 					"fontSize": "var:preset|font-size|small"
 				}
 			},
-			"core/post-terms": {
-				"typography": {
-					"fontWeight": "500",
-					"textTransform": "uppercase"
-				}
-			},
-			"core/post-title": {
-				"typography": {
-					"fontWeight": "200",
-					"letterSpacing": "-2.32px"
-				}
-			},
 			"core/pullquote": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|roboto-slab",
-					"fontSize": "var:preset|font-size|x-large",
+					"fontSize": "var:preset|font-size|xx-large",
 					"fontWeight": "200"
-				}
-			},
-			"core/query-title": {
-				"typography": {
-					"fontWeight": "300"
 				}
 			},
 			"core/search": {
@@ -59,14 +88,6 @@
 			"core/site-tagline": {
 				"typography": {
 					"fontSize": "var:preset|font-size|large"
-				}
-			},
-			"core/site-title": {
-				"typography": {
-					"fontWeight": "500",
-					"letterSpacing": "-0.28px",
-					"lineHeight": "1.3",
-					"textTransform": "uppercase"
 				}
 			}
 		},
@@ -84,22 +105,10 @@
 					"letterSpacing": "-0.5px"
 				}
 			},
-			"h5": {
-				"typography": {
-					"fontWeight": "400",
-					"letterSpacing": "0px"
-				}
-			},
-			"h6": {
-				"typography": {
-					"fontWeight": "400",
-					"letterSpacing": "1px"
-				}
-			},
 			"heading": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|roboto-slab",
-					"fontWeight": "200",
+					"fontWeight": "300",
 					"letterSpacing": "-0.5px",
 					"lineHeight": "1.2"
 				}

--- a/styles/typography/typography-preset-4.json
+++ b/styles/typography/typography-preset-4.json
@@ -73,6 +73,11 @@
 					"fontSize": "var:preset|font-size|small"
 				}
 			},
+			"core/post-terms": {
+				"typography": {
+					"fontWeight": "500"
+				}
+			},
 			"core/pullquote": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|roboto-slab",
@@ -90,9 +95,9 @@
 					"fontSize": "var:preset|font-size|large"
 				}
 			},
-			"core/post-terms": {
+			"core/site-title": {
 				"typography": {
-					"fontWeight": "500"
+					"textTransform": "uppercase"
 				}
 			}
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Updates Twilight and typography preset 4 according to https://github.com/WordPress/twentytwentyfive/issues/540

Under styles > typography, I did not add font weight 300 and line height 1.4 because they are already used as the default in theme.json. The variation and preset will inherit the styles from there.

**Testing Instructions**
Test the Twilight combined style variation and the Roboto Slab & Manrope preset. Confirm that they match the typography styles that are listed in the issue.