### PR TITLE
Try: Update instagram grid pattern to use the group (option 2)

### DIFF
--- a/patterns/media-instagram-grid.php
+++ b/patterns/media-instagram-grid.php
@@ -16,23 +16,22 @@
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"grid","minimumColumnWidth":"18rem"}} -->
 	<div class="wp-block-group alignwide">
-		<!-- wp:cover {"overlayColor":"contrast","isUserOverlayColor":true,"isDark":false,"style":{"dimensions":{"aspectRatio":"1"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"textColor":"base"} -->
-		<div class="wp-block-cover is-light has-base-color has-text-color has-link-color">
-			<span aria-hidden="true" class="wp-block-cover__background has-contrast-background-color has-background-dim-100 has-background-dim"></span>
-			<div class="wp-block-cover__inner-container">
-				<!-- wp:group {"style":{"dimensions":{"minHeight":"100%"},"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical","verticalAlignment":"center","justifyContent":"center"}} -->
-				<div class="wp-block-group" style="min-height:100%">
-					<!-- wp:heading {"fontSize":"large"} -->
-					<h2 class="wp-block-heading has-large-font-size"><?php esc_html_e( 'Instagram', 'twentytwentyfive' ); ?></h2>
-					<!-- /wp:heading -->
-					<!-- wp:paragraph {"align":"center","fontSize":"medium"} -->
-					<p class="has-text-align-center has-medium-font-size"><a href="#"><?php echo esc_html_x( '@example', 'Example username for social media account.', 'twentytwentyfive' ); ?></a></p>
-					<!-- /wp:paragraph -->
-				</div>
-				<!-- /wp:group -->
+		<!-- wp:group {"className":"is-style-section-3","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group is-style-section-3" style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)">
+			<!-- wp:group {"style":{"dimensions":{"minHeight":"100%"},"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical","verticalAlignment":"center","justifyContent":"center"}} -->
+			<div class="wp-block-group" style="min-height:100%">
+				<!-- wp:heading {"fontSize":"large"} -->
+				<h2 class="wp-block-heading has-large-font-size"><?php esc_html_e( 'Instagram', 'twentytwentyfive' ); ?></h2>
+				<!-- /wp:heading -->
+
+				<!-- wp:paragraph {"align":"center","fontSize":"medium"} -->
+				<p class="has-text-align-center has-medium-font-size"><a href="#"><?php echo esc_html_x( '@example', 'Example username for social media account.', 'twentytwentyfive' ); ?></a></p>
+				<!-- /wp:paragraph -->
 			</div>
+			<!-- /wp:group -->
 		</div>
-		<!-- /wp:cover -->
+		<!-- /wp:group -->
+
 
 		<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
 		<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/flower-meadow-square.webp" alt="<?php esc_attr_e( 'Photo of a field full of flowers, a blue sky and a tree.', 'twentytwentyfive' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Potential fix to https://github.com/WordPress/twentytwentyfive/issues/468

I'm updating the Instagram grid to have a group block in the first square, using the section styles and having vertical padding so that it doesn't look too short on mobile.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

https://github.com/user-attachments/assets/3599082e-f431-480d-b132-a4bfaecb73e1

**Testing Instructions**

1. Create a page.
2. Add the pattern.
3. Test the page in different style variations, confirm that the colors are accessible and look good.
4. View the page in different viewports, confirm that it looks good.
