### PR TITLE
update: tag line height

### DIFF
--- a/styles/blocks/post-terms-1.json
+++ b/styles/blocks/post-terms-1.json
@@ -22,7 +22,8 @@
 					}
 				},
 				"typography": {
-					"fontWeight": "400"
+					"fontWeight": "400",
+					"lineHeight": "2.8"
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Fix overlapping tags as noted in #465

**Screenshots**

<img width="730" alt="Screenshot 2024-10-11 at 12 14 23 AM" src="https://github.com/user-attachments/assets/21620299-d9d8-42ca-b85c-fdafa0bf235d">
