### PR TITLE
Afternoon: Update button colors

### DIFF
--- a/styles/04-afternoon.json
+++ b/styles/04-afternoon.json
@@ -196,6 +196,11 @@
 					"fontWeight": "600",
 					"letterSpacing": "1.44px",
 					"textTransform": "uppercase"
+				},
+				":hover": {
+					"color": {
+						"background": "color-mix(in srgb, var(--wp--preset--color--contrast) 85%, black)"
+					}
 				}
 			},
 			"heading": {
@@ -219,6 +224,28 @@
 						":hover": {
 							"color": {
 								"background": "color-mix(in srgb, var(--wp--preset--color--accent-1) 85%, transparent)"
+							}
+						}
+					}
+				}
+			},
+			"section-4": {
+				"elements": {
+					"button": {
+						":hover": {
+							"color": {
+								"background": "color-mix(in srgb, var(--wp--preset--color--accent-2) 85%, transparent)"
+							}
+						}
+					}
+				}
+			},
+			"section-5": {
+				"elements": {
+					"button": {
+						":hover": {
+							"color": {
+								"background": "color-mix(in srgb, var(--wp--preset--color--base) 88%, transparent)"
 							}
 						}
 					}

--- a/styles/04-afternoon.json
+++ b/styles/04-afternoon.json
@@ -245,7 +245,7 @@
 					"button": {
 						":hover": {
 							"color": {
-								"background": "color-mix(in srgb, var(--wp--preset--color--base) 88%, transparent)"
+								"background": "color-mix(in srgb, var(--wp--preset--color--base) 90%, transparent)"
 							}
 						}
 					}

--- a/styles/colors/04-afternoon.json
+++ b/styles/colors/04-afternoon.json
@@ -94,7 +94,7 @@
 					"button": {
 						":hover": {
 							"color": {
-								"background": "color-mix(in srgb, var(--wp--preset--color--base) 88%, transparent)"
+								"background": "color-mix(in srgb, var(--wp--preset--color--base) 90%, transparent)"
 							}
 						}
 					}

--- a/styles/colors/04-afternoon.json
+++ b/styles/colors/04-afternoon.json
@@ -49,6 +49,15 @@
 		}
 	},
 	"styles": {
+		"elements": {
+			"button": {
+				":hover": {
+					"color": {
+						"background": "color-mix(in srgb, var(--wp--preset--color--contrast) 85%, black)"
+					}
+				}
+			}
+		},
 		"variations": {
 			"section-2": {
 				"color": {
@@ -64,6 +73,28 @@
 						":hover": {
 							"color": {
 								"background": "color-mix(in srgb, var(--wp--preset--color--accent-1) 85%, transparent)"
+							}
+						}
+					}
+				}
+			},
+			"section-4": {
+				"elements": {
+					"button": {
+						":hover": {
+							"color": {
+								"background": "color-mix(in srgb, var(--wp--preset--color--accent-2) 85%, transparent)"
+							}
+						}
+					}
+				}
+			},
+			"section-5": {
+				"elements": {
+					"button": {
+						":hover": {
+							"color": {
+								"background": "color-mix(in srgb, var(--wp--preset--color--base) 88%, transparent)"
 							}
 						}
 					}


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This PR implements the changes to the color-mix CSS used for the button hover colors discussed here:
https://github.com/WordPress/twentytwentyfive/issues/492

In my testing, these are the resulting contrast ratios:

Outside section styles, section style 1, 3, 
Contrast Ratio: 6.5:1

Section style 2
Contrast Ratio: 7.18:1

Section style 4
Contrast Ratio: 7.96:1

Section style 5
Contrast Ratio: 4.52:1


**Screenshots**


https://github.com/user-attachments/assets/59667544-5b73-41c0-98f0-d956a655e119


**Testing Instructions**
Go to Appearance > Editor > Styles.
Activate "Afternoon".

Insert a buttons block:
One button with the filled variation, one with the outline variation. Remember to add the links.

Insert one group for each section style, add a copy of the buttons inside.

Test that the button colors have the expected, and accessible, colors on hover.
