### PR TITLE
Try: Remove link color in "Link format" pattern.

### DIFF
--- a/patterns/format-link.php
+++ b/patterns/format-link.php
@@ -17,8 +17,8 @@
 	<p style="font-style:normal;font-weight:700"><?php esc_html_e( 'The Stories Book, a fine collection of moments in time featuring photographs from Louis Fleckenstein, Paul Strand and Asahachi Kōno, is available for pre-order', 'twentytwentyfive' ); ?></p>
 	<!-- /wp:paragraph -->
 
-	<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|accent-4"}}}},"textColor":"accent-4","fontSize":"medium","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group has-accent-4-color has-text-color has-link-color has-medium-font-size">
+	<!-- wp:group {"fontSize":"medium","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group has-medium-font-size">
 		<!-- wp:paragraph -->
 		<p><a href="#"><?php esc_html_e( 'https://example.com', 'twentytwentyfive' ); ?></a></p>
 		<!-- /wp:paragraph -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

<!-- Describe the purpose or reason for the pull request -->

Fixes https://github.com/WordPress/twentytwentyfive/issues/558

Removing the link color so that it takes the color from the section, which was tested for a11y.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

**Before**

https://github.com/user-attachments/assets/073fe53e-4b4a-4a58-b144-60440940d23c

**After**

https://github.com/user-attachments/assets/f25e2f9f-b128-43c3-8dd2-fd1ed9d4ecf4

**Testing Instructions**

1. Create a page.
2. Add the link format pattern.
3. Test the link contrast ratio in all the styles variations and confirm that's accessible.
