### PR TITLE
Code quality: Fix style warning

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -44,7 +44,7 @@
 					"slug": "accent-5"
 				},
 				{
-					"color": "color-mix(in srgb, currentColor 20%, transparent);",
+					"color": "color-mix(in srgb, currentColor 20%, transparent)",
 					"name": "Accent 6",
 					"slug": "accent-6"
 				}
@@ -74,22 +74,22 @@
 				},
 				{
 					"name": "Regular",
-					"size": "clamp(30px, 5vw, 50px);",
+					"size": "clamp(30px, 5vw, 50px)",
 					"slug": "50"
 				},
 				{
 					"name": "Large",
-					"size": "clamp(30px, 7vw, 70px);",
+					"size": "clamp(30px, 7vw, 70px)",
 					"slug": "60"
 				},
 				{
 					"name": "X-Large",
-					"size": "clamp(50px, 7vw, 90px);",
+					"size": "clamp(50px, 7vw, 90px)",
 					"slug": "70"
 				},
 				{
 					"name": "XX-Large",
-					"size": "clamp(70px, 10vw, 140px);",
+					"size": "clamp(70px, 10vw, 140px)",
 					"slug": "80"
 				}
 			],


### PR DESCRIPTION
Fixes #481
Similar core ticket: https://core.trac.wordpress.org/ticket/57245

**Description**

This PR fixes the following React warning error:

```
Warning: Style property values shouldn't contain a semicolon. Try "borderTopColor: color-mix(in srgb, currentColor 20%, transparent)" instead.
```

**Screenshots**

![image](https://github.com/user-attachments/assets/54f0a6d1-54a7-4132-aecb-1e3bc6c059e9)

**Testing Instructions**

Note: To reproduce this issue, change `SCRIPT_DEBUG` to `true`.

- Open Site Editor > Patterns or open the color palette in the post editor.
- You should not see any warnings in your browser console.