### PR TITLE
Photo single post: Update post content settings

### DIFF
--- a/patterns/template-single-photo-blog.php
+++ b/patterns/template-single-photo-blog.php
@@ -84,18 +84,9 @@
 		<!-- wp:post-featured-image {"aspectRatio":"auto","align":"wide"} /-->
 		</div>
 	<!-- /wp:group -->
-	<!-- wp:columns {"align":"wide"} -->
-	<div class="wp-block-columns alignwide">
-		<!-- wp:column {"width":"66.66%"} -->
-		<div class="wp-block-column" style="flex-basis:66.66%">
-			<!-- wp:post-content {"align":"full","layout":{"type":"default"}} /-->
-		</div>
-		<!-- /wp:column -->
-		<!-- wp:column {"width":"33.33%"} -->
-		<div class="wp-block-column" style="flex-basis:33.33%"></div>
-		<!-- /wp:column -->
-	</div>
-	<!-- /wp:columns -->
+
+	<!-- wp:post-content {"align":"wide","layout":{"type":"constrained","justifyContent":"left"}} /-->
+
 	<!-- wp:group {"align":"wide","layout":{"type":"constrained","justifyContent":"left"}} -->
 	<div class="wp-block-group alignwide">
 		<!-- wp:pattern {"slug":"twentytwentyfive/comments"} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

When the Photo blog single post template is used, the content in the post editor (block editor) is touching the edge of the editor. It makes the content more difficult to edit.

This pull requests makes some adjustments to the pattern to solve this:
- It removes the columns block that the content block was placed inside.
- Changes the alignment from full to wide. This is to make sure that the content continues to be aligned with the rest of the elements on the page, including the featured image above the content.
- Changes the layout from default to constrained so that the wide and full width alignment options are enabled in the block editor.

Closes https://github.com/WordPress/twentytwentyfive/issues/529

**Screenshots**

Editor, after:
![image](https://github.com/user-attachments/assets/de8fa7f0-0c01-45f6-a2ed-e6f90120ad63)


**Testing Instructions**

Go to Appearance > Editor > Templates.
Select the single post template.
In the settings sidebar, open the Template tab.
Locate and open the Design panel.
Select the single post template for the photo blog.
Save.

Create a new post.

### Expected result:
- When you add the first paragraphs they are to the left below the post title, not centered below it.
- There is a comfortable amount of spacing between the blocks and the edge of the editor.
- When you add a block that supports wide and full width, such as an image or group, the wide and full width options are available in the block toolbars.

- When you view the post content on the front, it is not a 100% match to the editor.
In the editor, the full width block is slightly wider than the wide block. But on the front, full and wide have the same width.
This is not a bug with the theme. 

- The content is aligned to the left (unless it has been positioned using options!).
- The content aligns with the rest of the blocks on the page layout.

Test that the layout and the spacing around the content looks correct on different screen widths.
