### PR TITLE
Morning: Update the color contrast on the button in section style 4

### DIFF
--- a/styles/06-morning.json
+++ b/styles/06-morning.json
@@ -302,9 +302,10 @@
 						},
 						":hover": {
 							"color": {
-								"background": "color-mix(in srgb, var(--wp--preset--color--accent-1) 85%, transparent)"
+								"background": "color-mix(in srgb, var(--wp--preset--color--accent-1) 85%, transparent)",
+								"text": "var:preset|color|contrast"
+							}
 						}
-					}
 					},
 					"link": {
 						"color": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This PR updates the text color on the button element in the Morning variation when the button is placed in section style 4, and the button is hovered.
It overrides the text color that is set in styles/sections/section-4.json.

The resulting contrast ratio between the button text and the button text color is 5.08:1
Closes https://github.com/WordPress/twentytwentyfive/issues/492

**Screenshots**
On hover:
![image](https://github.com/user-attachments/assets/49e91018-501f-4314-9797-a97da544d65b)

**Testing Instructions**

Go to Appearance > Editor > Styles and enable "Morning".
Create a new post.
Insert a group block and apply section style 4.
In the group, insert a buttons block with a filled button.
Confirm that when you hover over the button, the text color is set to `contrast`.
