### PR TITLE
Link in bio with profile: Update color of the social icons

### DIFF
--- a/patterns/page-link-in-bio-wide-margins.php
+++ b/patterns/page-link-in-bio-wide-margins.php
@@ -38,7 +38,7 @@
 				<p><?php echo esc_html_x( 'I&rsquo;m Nora, a dedicated public interest attorney based in Denver. I&rsquo;m a graduate of Stanford University.', 'Pattern placeholder text.', 'twentytwentyfive' ); ?></p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:social-links {"iconColor":"contrast","iconColorValue":"#111111","className":"is-style-logos-only"} -->
+				<!-- wp:social-links {"iconColor":"currentColor","iconColorValue":"currentColor","className":"is-style-logos-only"} -->
 				<ul class="wp-block-social-links has-icon-color is-style-logos-only">
 					<!-- wp:social-link {"url":"#","service":"x"} /-->
 


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

The social icons in the "Link in bio with profile" pattern has too low color contrast ratio against the pattern's background color in two of the variations.

This pull request changes the color of the icons to `currentColor`. The color will be the same as the text color set on the section style that is applied on the pattern.

Closes https://github.com/WordPress/twentytwentyfive/issues/557

**Screenshots**

https://github.com/user-attachments/assets/021f3af3-c754-42d1-b73f-321dc9dd4071





**Testing Instructions**
**Note:** if you are testing the colors using the Site Editor, please activate the development version of Gutenberg, it includes a fix related to the section style colors.

Insert the "Link in bio with profile, links and wide margins" pattern.
Go to Appearance > Editor > Styles and test the pattern colors with the different combined theme styles.
Confirm that the social icons are visible.
