### PR TITLE
Remove the top margin from the footer template part

### DIFF
--- a/assets/css/editor-style.css
+++ b/assets/css/editor-style.css
@@ -6,3 +6,11 @@ a {
 	text-decoration-thickness: 1px !important;
 	text-underline-offset: .1em;
 }
+
+/*
+ * Remove the top margin from the footer template parts.
+ * https://github.com/WordPress/gutenberg/issues/47637
+ */
+footer.wp-block-template-part {
+	margin-block-start: 0;
+}

--- a/style.css
+++ b/style.css
@@ -44,3 +44,11 @@ h1, h2, h3, h4, h5, h6, blockquote, caption, figcaption, p {
 .more-link {
 	display: block;
 }
+
+/*
+ * Remove the top margin from the footer template parts.
+ * https://github.com/WordPress/gutenberg/issues/47637
+ */
+footer.wp-block-template-part {
+	margin-block-start: 0;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
The purpose of this change is to remove the spacing between the footer template part and full width, color patterns placed above it,

Partial for https://github.com/WordPress/twentytwentyfive/issues/404

**Screenshots**
Before:
![370705205-b17efa4d-f1bc-4019-b78a-1740ffe54b64](https://github.com/user-attachments/assets/da92b23a-8291-4839-80f6-02652e3c664f)

After
Partial screenshot just to show that the gap is gone:
![image](https://github.com/user-attachments/assets/5c98e3e7-0e24-456a-b864-36b13486ecc5)
(The size difference here is not related to the PR)

**Testing Instructions**
Create a new page. 
Select "Landing page for Book". 
Confirm that there is no gap between the footer and the last pattern.

Go to Appearance > Editor > Templates and select the Home template.
In the Design panel, select the News blog with featured posts grid, and save.
Confirm that there is no gap between the footer and the last pattern.