### PR TITLE
Update the viewport width of the vertical header

### DIFF
--- a/patterns/vertical-header.php
+++ b/patterns/vertical-header.php
@@ -5,6 +5,7 @@
  * Categories: header
  * Block Types: core/template-part/vertical-header
  * Description: Vertical Header with site title and navigation
+ * Viewport width: 300
  *
  * @package WordPress
  * @subpackage Twenty_Twenty_Five


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
In the header and pattern previews in the Site Editor, the vertical header is very small.
The CSS transform that is used on the pattern preview also animates the pattern which makes it look like it moves from the top to bottom.

This pull request adds a viewport width to the vertical header pattern, which makes the preview zoom in on the design closer.
It also reduces the impact of the animation.

**Screenshots**
In these videos I am refreshing the Patterns data view screen in the Site Editor.

Before:

https://github.com/user-attachments/assets/bbd1ad3e-ee9a-4a8c-a170-e25e3bd06f8c

After:

https://github.com/user-attachments/assets/8e8105dd-c0a4-48b6-9ba5-133772d9e9d0


**Testing Instructions**
Go to Appearance > Editor > Patterns > Headers
Confirm that the vertical header is more visible than before.
