### PR TITLE
Try different block bindings

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -157,7 +157,7 @@ if ( ! function_exists( 'twentytwentyfive_format_binding' ) ) :
 	function twentytwentyfive_format_binding() {
 		$post_format_slug = get_post_format();
 
-		if ( $post_format_slug && $post_format_slug !== 'standard' ) {
+		if ( $post_format_slug && 'standard' !== $post_format_slug ) {
 			return get_post_format_string( $post_format_slug );
 		}
 	}

--- a/functions.php
+++ b/functions.php
@@ -121,7 +121,7 @@ add_action( 'init', 'twentytwentyfive_pattern_categories' );
 // Registers block binding sources.
 if ( ! function_exists( 'twentytwentyfive_register_block_bindings' ) ) :
 	/**
-	 * Registers the copyright block binding source.
+	 * Registers the post format block binding source.
 	 *
 	 * @since Twenty Twenty-Five 1.0
 	 *
@@ -129,33 +129,54 @@ if ( ! function_exists( 'twentytwentyfive_register_block_bindings' ) ) :
 	 */
 	function twentytwentyfive_register_block_bindings() {
 		register_block_bindings_source(
-			'twentytwentyfive/copyright',
+			'twentytwentyfive/format',
 			array(
-				'label'              => _x( '&copy; YEAR', 'Label for the copyright placeholder in the editor', 'twentytwentyfive' ),
-				'get_value_callback' => 'twentytwentyfive_copyright_binding',
+				'label'              => _x( 'Post format name', 'Label for the block binding placeholder in the editor', 'twentytwentyfive' ),
+				'get_value_callback' => 'twentytwentyfive_format_binding',
+			)
+		);
+		register_block_bindings_source(
+			'twentytwentyfive/category',
+			array(
+				'label'              => _x( 'First category', 'Label for the block binding placeholder in the editor', 'twentytwentyfive' ),
+				'get_value_callback' => 'twentytwentyfive_category_binding',
 			)
 		);
 	}
 endif;
 
-// Registers block binding callback function for the copyright.
-if ( ! function_exists( 'twentytwentyfive_copyright_binding' ) ) :
+// Registers block binding callback function for the post format name.
+if ( ! function_exists( 'twentytwentyfive_format_binding' ) ) :
 	/**
-	 * Callback function for the copyright block binding source.
+	 * Callback function for the post format name block binding source.
 	 *
 	 * @since Twenty Twenty-Five 1.0
 	 *
-	 * @return string Copyright text.
+     * @return string|void Post format name, or nothing if the format is 'standard'.
 	 */
-	function twentytwentyfive_copyright_binding() {
-		$copyright_text = sprintf(
-			/* translators: 1: Copyright symbol or word, 2: Year */
-			esc_html__( '%1$s %2$s', 'twentytwentyfive' ),
-			'&copy;',
-			wp_date( 'Y' )
-		);
+	function twentytwentyfive_format_binding() {
+		$post_format_slug = get_post_format();
 
-		return $copyright_text;
+		if ( $post_format_slug && $post_format_slug !== 'standard' ) {
+			return get_post_format_string( $post_format_slug );
+		}
+	}
+endif;
+
+// Registers block binding callback function for the first category on a post.
+if ( ! function_exists( 'twentytwentyfive_category_binding' ) ) :
+	/**
+	 * Callback function for the category block binding source.
+	 *
+	 * @since Twenty Twenty-Five 1.0
+	 *
+     * @return string|void Category name, or nothing if the are no categories.
+	 */
+	function twentytwentyfive_category_binding() {
+		$categories = get_the_category();
+		if ( ! empty( $categories ) ) {
+			return esc_html( $categories[0]->name );
+		}
 	}
 endif;
 add_action( 'init', 'twentytwentyfive_register_block_bindings' );

--- a/functions.php
+++ b/functions.php
@@ -152,7 +152,7 @@ if ( ! function_exists( 'twentytwentyfive_format_binding' ) ) :
 	 *
 	 * @since Twenty Twenty-Five 1.0
 	 *
-     * @return string|void Post format name, or nothing if the format is 'standard'.
+	 * @return string|void Post format name, or nothing if the format is 'standard'.
 	 */
 	function twentytwentyfive_format_binding() {
 		$post_format_slug = get_post_format();
@@ -170,7 +170,7 @@ if ( ! function_exists( 'twentytwentyfive_category_binding' ) ) :
 	 *
 	 * @since Twenty Twenty-Five 1.0
 	 *
-     * @return string|void Category name, or nothing if the are no categories.
+	 * @return string|void Category name, or nothing if the are no categories.
 	 */
 	function twentytwentyfive_category_binding() {
 		$categories = get_the_category();

--- a/patterns/binding-category.php
+++ b/patterns/binding-category.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Title: First category
+ * Slug: twentytwentyfive/binding-category
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"twentytwentyfive/category"}}},"fontSize":"small"} -->
+<p class="has-small-font-size"></p>
+<!-- /wp:paragraph -->

--- a/patterns/binding-format.php
+++ b/patterns/binding-format.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Title: Post format name
+ * Slug: twentytwentyfive/binding-format
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"twentytwentyfive/format"}}},"fontSize":"small"} -->
+<p class="has-small-font-size"></p>
+<!-- /wp:paragraph -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
This is for testing only.

I have registered two possible block bindings.
I have used patterns to display the binding to not limit where we can place them when testing.

The first displays the post format name.
Use case: To use in the single post view next to author/categories/etc, or in the post format patterns.
This binding only shows the post format name: "Link".  It could also be updated to use a prefix: "Format: Link".
If there is no format assigned, nothing shows.

The second displays the first category on the post, alphabetically.
Use case: Limiting the number of categories to show
This binding only shows the category name: "Apples".  It could also be updated to use a prefix: "Category: Apples".
The text is not linked, but could be.

> Perhaps the News blog templates would be good places to try (only the Blog templates, not the Single post templates though). Given that these designs contemplate one category for each post as a way to reduce the amount of information on the homepage.
>Maybe:
> News blog home
> News blog with featured posts grid
> News blog with sidebar



To test, create one or more posts with categories and or formats.
Insert the pattern where you want to test it, in a template, or content.

