### PR TITLE
News blog with featured posts grid: Replace footer

### DIFF
--- a/parts/footer-columns.html
+++ b/parts/footer-columns.html
@@ -1,0 +1,1 @@
+<!-- wp:pattern {"slug":"twentytwentyfive/footer-columns"} /-->

--- a/patterns/template-home-posts-grid-news-blog.php
+++ b/patterns/template-home-posts-grid-news-blog.php
@@ -133,4 +133,4 @@
 
 <!-- wp:pattern {"slug":"twentytwentyfive/cta-newsletter"} /-->
 
-<!-- wp:template-part {"slug":"footer-newsletter"} /-->
+<!-- wp:template-part {"slug":"footer-columns"} /-->

--- a/theme.json
+++ b/theme.json
@@ -1472,6 +1472,11 @@
 		},
 		{
 			"area": "footer",
+			"name": "footer-columns",
+			"title": "Footer Columns"
+		},
+		{
+			"area": "footer",
 			"name": "footer-newsletter",
 			"title": "Footer Newsletter"
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

This PR closes https://github.com/WordPress/twentytwentyfive/issues/404 and replaces https://github.com/WordPress/twentytwentyfive/pull/572

It replaces the footer with the newsletter-signup with the footer with the columns in the pattern
"News blog with featured posts grid".

In order to add the footer with the columns, a new footer template part was created, to make it easier for users to use the same footer across the site, _**if they want.**_

**Screenshots**
After:

![image](https://github.com/user-attachments/assets/f5d80cae-2256-48e9-9cae-eb93135fe77b)


**Testing Instructions**

Go to Appearance > Editor > Templates.
Select the blog home template.
In the Template tab, open the Design panel.
Select the design "News blog with featured posts grid".
Preview the footer.
Confirm that the newsletter-signup pattern shows above the footer with the columns (two columns with lists of links).
