### PR TITLE
Try: Fix display of the annotation.

### DIFF
--- a/styles/blocks/03-annotation.json
+++ b/styles/blocks/03-annotation.json
@@ -5,7 +5,7 @@
 	"slug": "text-annotation",
 	"blockTypes": ["core/heading", "core/paragraph"],
 	"styles": {
-		"css": "display: inline-flex",
+		"css": "width: fit-content; margin-inline: max(0px, ((100% - var(--wp--style--global--content-size)) / 2))",
 		"typography": {
 			"fontSize": "var:preset|font-size|small",
 			"lineHeight": "1.5",

--- a/styles/blocks/03-annotation.json
+++ b/styles/blocks/03-annotation.json
@@ -5,7 +5,7 @@
 	"slug": "text-annotation",
 	"blockTypes": ["core/heading", "core/paragraph"],
 	"styles": {
-		"css": "width: fit-content; margin-inline: max(0px, ((100% - var(--wp--style--global--content-size)) / 2))",
+		"css": "width: fit-content",
 		"typography": {
 			"fontSize": "var:preset|font-size|small",
 			"lineHeight": "1.5",


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Fixes https://github.com/WordPress/twentytwentyfive/issues/555

Changing the display so that it shows in context in the editor, and using a width to adjust to its content.

The alignment of the annotation will depend of its parent element (stack, for example).

**Screenshots**

<!-- Add screenshots of the change, if applicable -->
https://github.com/user-attachments/assets/73964f09-0504-4a5a-b997-2a4c74c4264d

**Testing Instructions**

1. Create a page.
2. Add a paragraph of "annotation" style.
3. Confirm that the paragraph is located in context and not on the left as it was before.
