### PR TITLE
Test category block binding in news blog template

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -117,3 +117,44 @@ if ( ! function_exists( 'twentytwentyfive_pattern_categories' ) ) :
 	}
 endif;
 add_action( 'init', 'twentytwentyfive_pattern_categories' );
+
+// Registers block binding sources.
+if ( ! function_exists( 'twentytwentyfive_register_block_bindings' ) ) :
+	/**
+	 * Registers the category block binding source.
+	 *
+	 * @since Twenty Twenty-Five 1.0
+	 *
+	 * @return void
+	 */
+	function twentytwentyfive_register_block_bindings() {
+		register_block_bindings_source(
+			'twentytwentyfive/category',
+			array(
+				'label'              => _x( 'First category', 'Label for the block binding placeholder in the editor', 'twentytwentyfive' ),
+				'get_value_callback' => 'twentytwentyfive_category_binding',
+			)
+		);
+	}
+endif;
+
+// Registers block binding callback function for the first category on a post.
+if ( ! function_exists( 'twentytwentyfive_category_binding' ) ) :
+	/**
+	 * Callback function for the category block binding source.
+	 *
+	 * @since Twenty Twenty-Five 1.0
+	 *
+	 * @return string|void Category name, or nothing if the are no categories.
+	 */
+	function twentytwentyfive_category_binding() {
+		$categories = get_the_category();
+
+		if ( ! empty( $categories ) ) {
+			$category_name = esc_html( $categories[0]->name );
+			$category_link = esc_url( get_category_link( $categories[0]->term_id ) );
+			return sprintf( '<a href="%s">%s</a>', $category_link, $category_name );
+		}
+	}
+endif;
+add_action( 'init', 'twentytwentyfive_register_block_bindings' );

--- a/patterns/template-home-news-blog.php
+++ b/patterns/template-home-news-blog.php
@@ -32,6 +32,9 @@
 								<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"3/2"} /-->
 								<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
 								<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
+								<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"twentytwentyfive/category"}}},"fontSize":"small","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px","fontStyle":"normal","fontWeight":"600"}}} -->
+								<p class="has-small-font-size" style="font-style:normal;font-weight:600;letter-spacing:1.4px;text-transform:uppercase"></p>
+								<!-- /wp:paragraph -->
 							</div>
 							<!-- /wp:group -->
 						<!-- /wp:post-template -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Testing Instructions**

Go to Appearance > Editor > Templates
Select Blog home
In the Design panel, select  News blog home. Save

Go to the front of the site.
Look at the first post on the top left.
Confirm that it has two categories showing.
The top one, is the terms block. 
The second one is the new block binding.

Test the style of this block binding in different style variations.