### PR TITLE
change: remove text color on theme name

### DIFF
--- a/patterns/page-portfolio-home.php
+++ b/patterns/page-portfolio-home.php
@@ -222,8 +222,8 @@
 	<div class="wp-block-group alignwide">
 		<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
 		<div class="wp-block-group alignwide">
-			<!-- wp:paragraph {"textColor":"accent-4","fontSize":"small"} -->
-			<p class="has-accent-4-color has-text-color has-small-font-size"><?php esc_html_e( 'Twenty Twenty-Five', 'twentytwentyfive' ); ?></p>
+			<!-- wp:paragraph {""fontSize":"small"} -->
+			<p class="has-small-font-size"><?php esc_html_e( 'Twenty Twenty-Five', 'twentytwentyfive' ); ?></p>
 			<!-- /wp:paragraph -->
 			<!-- wp:paragraph {"fontSize":"small"} -->
 			<p class="has-small-font-size"><?php esc_html_e( 'email@example.com', 'twentytwentyfive' ); ?><br><?php echo esc_html_x( '+1 555 349 1806', 'Phone number.', 'twentytwentyfive' ); ?></p>


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Removed text color markup in the portfolio homepage as per #592 

**Screenshots**

<img width="270" alt="evening" src="https://github.com/user-attachments/assets/ca9969c7-7e65-4647-98c7-3123e7e59e8d">
<img width="257" alt="default" src="https://github.com/user-attachments/assets/c8e3fe57-cdd0-44a7-87c3-18ec7bc1afef">
<img width="304" alt="dusk" src="https://github.com/user-attachments/assets/9c2ef707-fa99-4da1-9cf6-9bdfc6bc1b7c">
<img width="244" alt="noon" src="https://github.com/user-attachments/assets/b1325f74-7330-4d5b-951d-e4b90e4c8368">
<img width="262" alt="afternoon" src="https://github.com/user-attachments/assets/b7ef3375-4ec4-4587-9cc6-5d32f4586cb3">
<img width="241" alt="twilight" src="https://github.com/user-attachments/assets/62b13b32-e109-4242-9fab-2541ddb79672">
<img width="239" alt="morning" src="https://github.com/user-attachments/assets/88c61a7a-981f-4866-b2e8-97b633ffbb62">
<img width="267" alt="sunrise" src="https://github.com/user-attachments/assets/230e7cfe-4a18-4b9e-8f00-f9ff1bde7689">
<img width="267" alt="midnight" src="https://github.com/user-attachments/assets/e49ee152-3b76-4bdf-a7de-7be98e790498">
