### PR TITLE
Add the "post format name" block binding

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -117,3 +117,41 @@ if ( ! function_exists( 'twentytwentyfive_pattern_categories' ) ) :
 	}
 endif;
 add_action( 'init', 'twentytwentyfive_pattern_categories' );
+
+// Registers the block binding source.
+if ( ! function_exists( 'twentytwentyfive_register_block_bindings' ) ) :
+	/**
+	 * Registers the post format name block binding source.
+	 *
+	 * @since Twenty Twenty-Five 1.0
+	 *
+	 * @return void
+	 */
+	function twentytwentyfive_register_block_bindings() {
+		register_block_bindings_source(
+			'twentytwentyfive/format',
+			array(
+				'label'              => _x( 'Post format name', 'Label for the block binding placeholder in the editor', 'twentytwentyfive' ),
+				'get_value_callback' => 'twentytwentyfive_format_binding',
+			)
+		);
+	}
+endif;
+
+// Registers block binding callback function for the post format name.
+if ( ! function_exists( 'twentytwentyfive_format_binding' ) ) :
+	/**
+	 * Callback function for the post format name block binding source.
+	 *
+	 * @since Twenty Twenty-Five 1.0
+	 *
+	 * @return string|void Post format name, or nothing if the format is 'standard'.
+	 */
+	function twentytwentyfive_format_binding() {
+		$post_format_slug = get_post_format();
+		if ( $post_format_slug && 'standard' !== $post_format_slug ) {
+			return get_post_format_string( $post_format_slug );
+		}
+	}
+endif;
+add_action( 'init', 'twentytwentyfive_register_block_bindings' );

--- a/patterns/format-name.php
+++ b/patterns/format-name.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Title: Post format name
+ * Slug: twentytwentyfive/format-name
+ * Categories: twentytwentyfive_post-format
+ * Description: Prints the name of the post format with the help of the Block Bindings API.
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty_Five
+ * @since Twenty Twenty-Five 1.0
+ */
+
+?>
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"twentytwentyfive/format"}}},"fontSize":"small"} -->
+<p class="has-small-font-size"></p>
+<!-- /wp:paragraph -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Adds a block binding that displays the post format name. If the standard post format is used, the name is not printed.

Adds a pattern to help user insert the post format name using a paragraph block.
For this pattern, I used the same pattern category that is used for the other two post format patterns: `twentytwentyfive_post-format`

Feel free to adjust any part of the PR including the naming and description.

**Testing Instructions**

To test, create one or more posts with post formats assigned.
Insert the pattern where you want to test it, in a template or content.
