### PR TITLE
update: removed purple site title link color in dusk theme

### DIFF
--- a/styles/03-dusk.json
+++ b/styles/03-dusk.json
@@ -67,6 +67,15 @@
 					"background": "var:preset|color|accent-5"
 				}
 			},
+			"core/paragraph": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var:preset|color|accent-2"
+						}
+					}
+				}
+			},
 			"core/post-author-name": {
 				"typography": {
 					"fontWeight": "300"
@@ -78,6 +87,14 @@
 					"link": {
 						"color": {
 							"text": "var:preset|color|accent-2"
+						},
+						"typography": {
+							"textDecoration": "underline"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "none"
+							}
 						}
 					}
 				}
@@ -93,6 +110,14 @@
 					"link": {
 						"color": {
 							"text": "var:preset|color|accent-2"
+						},
+						"typography": {
+							"textDecoration": "underline"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "none"
+							}
 						}
 					}
 				}
@@ -234,6 +259,14 @@
 							"radius": "4px",
 							"width": "0.8px",
 							"style": "solid"
+						},
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
 						}
 					}
 				}

--- a/styles/03-dusk.json
+++ b/styles/03-dusk.json
@@ -67,15 +67,6 @@
 					"background": "var:preset|color|accent-5"
 				}
 			},
-			"core/paragraph": {
-				"elements": {
-					"link": {
-						"color": {
-							"text": "var:preset|color|accent-2"
-						}
-					}
-				}
-			},
 			"core/post-author-name": {
 				"typography": {
 					"fontWeight": "300"

--- a/styles/colors/03-dusk.json
+++ b/styles/colors/03-dusk.json
@@ -65,7 +65,7 @@
 				"elements": {
 					"link": {
 						"color": {
-							"text": "var:preset|color|accent-2"
+							"text": "var:preset|color|accent-6"
 						}
 					}
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

This addresses #604. Removed paragraph link style that impacts site title and compared to other styles, which do not seem to have this link style in place. Some screenshots of how link in a para is treated with just an underline, no specific color treatment.

**Screenshots**

<img width="1034" alt="example-2" src="https://github.com/user-attachments/assets/0376888f-d690-4d98-b40f-f808050fb9bd">
<img width="1031" alt="example-3" src="https://github.com/user-attachments/assets/2c53573c-2ee2-42cf-9535-ddcb2dafb48a">
<img width="1031" alt="example-4" src="https://github.com/user-attachments/assets/bd6d498d-7aae-4781-a4c0-08a8d94aab58">
<img width="1034" alt="example-1" src="https://github.com/user-attachments/assets/b6cddf08-0efd-4316-a510-63954b9eacd0">