### PR TITLE
update: column widths on poster-like patter

### DIFF
--- a/patterns/banner-poster.php
+++ b/patterns/banner-poster.php
@@ -18,16 +18,16 @@
 	<div class="wp-block-group alignwide" style="min-height:100vh">
 		<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50"}}}} -->
 		<div class="wp-block-columns alignwide">
-			<!-- wp:column {"width":"66.66%"} -->
-			<div class="wp-block-column" style="flex-basis:66.66%">
+			<!-- wp:column {"width":"80%"} -->
+			<div class="wp-block-column" style="flex-basis:80%">
 				<!-- wp:heading {"textAlign":"left","align":"wide","style":{"typography":{"fontSize":"12vw","lineHeight":"0.9","fontStyle":"normal","fontWeight":"300"}}} -->
 				<h2 class="wp-block-heading alignwide has-text-align-left" style="font-size:12vw;font-style:normal;font-weight:300;line-height:0.9"><?php echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Sample heading in four languages.', 'twentytwentyfive' ); ?></h2>
 				<!-- /wp:heading -->
 			</div>
 			<!-- /wp:column -->
 
-			<!-- wp:column {"width":"33.33%"} -->
-			<div class="wp-block-column" style="flex-basis:33.33%">
+			<!-- wp:column {"width":"20%"} -->
+			<div class="wp-block-column" style="flex-basis:20%">
 				<!-- wp:paragraph {"align":"right"} -->
 				<p class="has-text-align-right"><?php echo esc_html_x( 'Mon, Jan 1', 'Example event date in pattern.', 'twentytwentyfive' ); ?></p>
 				<!-- /wp:paragraph -->
@@ -38,16 +38,16 @@
 
 		<!-- wp:columns {"verticalAlignment":"bottom","isStackedOnMobile":false,"align":"wide"} -->
 		<div class="wp-block-columns alignwide are-vertically-aligned-bottom is-not-stacked-on-mobile">
-			<!-- wp:column {"verticalAlignment":"bottom","width":"66.66%"} -->
-			<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:66.66%">
+			<!-- wp:column {"verticalAlignment":"bottom","width":"80%"} -->
+			<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:80%">
 				<!-- wp:heading {"textAlign":"left","align":"wide","style":{"typography":{"lineHeight":"0.9","fontStyle":"normal","fontWeight":"300"}},"fontSize":"xx-large"} -->
 				<h2 class="wp-block-heading alignwide has-text-align-left has-xx-large-font-size" style="font-style:normal;font-weight:300;line-height:0.9"><?php esc_html_e( 'Let’s hear them.', 'twentytwentyfive' ); ?></h2>
 				<!-- /wp:heading -->
 			</div>
 			<!-- /wp:column -->
 
-			<!-- wp:column {"verticalAlignment":"bottom","width":"33.33%"} -->
-			<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:33.33%">
+			<!-- wp:column {"verticalAlignment":"bottom","width":"20%"} -->
+			<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:20%">
 				<!-- wp:paragraph {"align":"right"} -->
 				<p class="has-text-align-right"><?php esc_html_e( '#stories', 'twentytwentyfive' ); ?></p>
 				<!-- /wp:paragraph -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

This PR addresses #606 by changing the column widths to 80 and 20 in both instances of the block to allow for the larger font size in the example to properly fit at larger widths

**Screenshots**

<img width="2055" alt="example" src="https://github.com/user-attachments/assets/8dd58123-3ed5-427b-81d2-8005891f3fcc">

**Testing Instructions**

1. Create new page
2. Add "Poster-like" pattern
3. Save and view front end at more than 1900px wide (I tested at 2056)