### PR TITLE
Sunrise & preset 6: Remove font size from author name

### DIFF
--- a/styles/07-sunrise.json
+++ b/styles/07-sunrise.json
@@ -71,9 +71,6 @@
 				}
 			},
 			"core/post-author-name": {
-				"typography": {
-					"fontSize": "var:preset|font-size|medium"
-				},
 				"color": {
 					"text": "var:preset|color|contrast"
 				},

--- a/styles/typography/typography-preset-6.json
+++ b/styles/typography/typography-preset-6.json
@@ -17,9 +17,6 @@
 				}
 			},
 			"core/post-author-name": {
-				"typography": {
-					"fontSize": "var:preset|font-size|medium"
-				},
 				"elements": {
 					"link": {
 						"typography": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

This PR removes the default font size from the post author name in the Sunrise theme style variation and typography preset 6.
Closes https://github.com/WordPress/twentytwentyfive/issues/613

**Testing Instructions**
View the author name below the featured image in the default single post template.
All the text "Written by name in category" should have the same font size.

