### PR TITLE
Try: Update underline thickness

### DIFF
--- a/assets/css/editor-style.css
+++ b/assets/css/editor-style.css
@@ -2,7 +2,8 @@
  * Link styles
  * https://github.com/WordPress/gutenberg/issues/42319
  */
-a {
+a,
+.wp-block[style*="text-decoration: underline"] {
 	text-decoration-thickness: 1px !important;
 	text-underline-offset: .1em;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
An attempt to solve https://github.com/WordPress/twentytwentyfive/issues/612
I can clearly see the difference in the underline thickness in the screenshots in the issue, but I can't actually see it in the browser. I tried Chrome and Firefox on Windows. So I will need help determining if this change solves the problem.

**Testing Instructions**
View the default single post template in the Site Editor.
**It needs to be the Site Editor**, because in this editor, the category in the post terms is not a link.
Below the featured image, observer the thickness of the underlines on the post author name and the category.
The thickness should be the same, 1px.
