### PR TITLE
Fix: Poster-like date text

### DIFF
--- a/patterns/banner-poster.php
+++ b/patterns/banner-poster.php
@@ -29,7 +29,7 @@
 			<!-- wp:column {"width":"33.33%"} -->
 			<div class="wp-block-column" style="flex-basis:33.33%">
 				<!-- wp:paragraph {"align":"right"} -->
-				<p class="has-text-align-right"><?php echo esc_html_x( 'Mon, Jan 1', 'Example event date in pattern.', 'twentytwentyfive' ); ?></p>
+				<p class="has-text-align-right"><?php esc_html_e( 'Aug 08—10 2025', 'twentytwentyfive' ); ?><br><?php esc_html_e( 'Fuego Bar, Mexico City', 'twentytwentyfive' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:column -->

--- a/patterns/banner-poster.php
+++ b/patterns/banner-poster.php
@@ -29,7 +29,7 @@
 			<!-- wp:column {"width":"33.33%"} -->
 			<div class="wp-block-column" style="flex-basis:33.33%">
 				<!-- wp:paragraph {"align":"right"} -->
-				<p class="has-text-align-right"><?php esc_html_e( 'Aug 08—10 2025', 'twentytwentyfive' ); ?><br><?php esc_html_e( 'Fuego Bar, Mexico City', 'twentytwentyfive' ); ?></p>
+				<p class="has-text-align-right"><?php echo esc_html_x( 'Aug 08—10 2025', 'Example event date in pattern.', 'twentytwentyfive' ); ?><br><?php esc_html_e( 'Fuego Bar, Mexico City', 'twentytwentyfive' ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:column -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Partial for https://github.com/WordPress/twentytwentyfive/pull/611

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

https://github.com/user-attachments/assets/3ba5935a-6fa0-41ec-b5d3-6c6de903c793




**Testing Instructions**

1. Create a page
2. Add the pattern.
3. confirm the text is like in the design.
