### PR TITLE
Fix/621 page with comments does not display comments

### DIFF
--- a/templates/page-no-title.html
+++ b/templates/page-no-title.html
@@ -1,8 +1,15 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0"}}}} -->
-<main class="wp-block-group" style="margin-top:0">
-	<!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} /-->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull"
+		style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+
+		<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
+		<!-- wp:pattern {"slug":"twentytwentyfive/comments"} /-->
+	</div>
+	<!-- /wp:group -->
 </main>
 <!-- /wp:group -->
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -7,6 +7,7 @@
 		<!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} /-->
 		<!-- wp:post-title {"level":1} /-->
 		<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
+		<!-- wp:pattern {"slug":"twentytwentyfive/comments"} /-->
 	</div>
 	<!-- /wp:group -->
 </main>


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Closes https://github.com/WordPress/twentytwentyfive/issues/621

The default page template and the page no title template did not display comments by default and with this fix, they should display as seen below.

**Screenshots**
<img width="765" alt="Screenshot 2024-10-22 at 11 45 57 AM" src="https://github.com/user-attachments/assets/6455d204-7224-42c5-9897-04db436c1397">
<img width="734" alt="Screenshot 2024-10-22 at 11 48 42 AM" src="https://github.com/user-attachments/assets/047eca3f-5be3-4587-98d3-d81bc3cbdb99">

**Testing**
1. Install theme unit test data.
2. Visit the "Page with comments" page - comments should be visible along with the form.
3. Change the template for this page to "Page no title".
4. Visit the "Page with comments" again - comments and form should be visible and nicely aligned at all screen sizes.