### PR TITLE
Add translator note for multilingual strings.

### DIFF
--- a/patterns/banner-poster.php
+++ b/patterns/banner-poster.php
@@ -24,7 +24,7 @@
 				<h2 class="wp-block-heading alignwide has-text-align-left" style="font-size:12vw;font-style:normal;font-weight:300;line-height:0.9">
 					<?php
 						/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
-						echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Sample heading in four languages.', 'twentytwentyfive' );
+						echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Placeholder heading in four languages.', 'twentytwentyfive' );
 					?>
 				</h2>
 				<!-- /wp:heading -->

--- a/patterns/banner-poster.php
+++ b/patterns/banner-poster.php
@@ -23,8 +23,10 @@
 				<!-- wp:heading {"textAlign":"left","align":"wide","style":{"typography":{"fontSize":"12vw","lineHeight":"0.9","fontStyle":"normal","fontWeight":"300"}}} -->
 				<h2 class="wp-block-heading alignwide has-text-align-left" style="font-size:12vw;font-style:normal;font-weight:300;line-height:0.9">
 					<?php
+					echo wp_kses_post(
 						/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
-						echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Placeholder heading in four languages.', 'twentytwentyfive' );
+						_x( '“Stories, <span lang="es">historias</span>, <span lang="uk">iсторії</span>, <span lang="el">iστορίες</span>”', 'Placeholder heading in four languages.', 'twentytwentyfive' )
+					);
 					?>
 				</h2>
 				<!-- /wp:heading -->

--- a/patterns/banner-poster.php
+++ b/patterns/banner-poster.php
@@ -21,7 +21,12 @@
 			<!-- wp:column {"width":"80%"} -->
 			<div class="wp-block-column" style="flex-basis:80%">
 				<!-- wp:heading {"textAlign":"left","align":"wide","style":{"typography":{"fontSize":"12vw","lineHeight":"0.9","fontStyle":"normal","fontWeight":"300"}}} -->
-				<h2 class="wp-block-heading alignwide has-text-align-left" style="font-size:12vw;font-style:normal;font-weight:300;line-height:0.9"><?php echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Sample heading in four languages.', 'twentytwentyfive' ); ?></h2>
+				<h2 class="wp-block-heading alignwide has-text-align-left" style="font-size:12vw;font-style:normal;font-weight:300;line-height:0.9">
+					<?php
+						/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
+						echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Sample heading in four languages.', 'twentytwentyfive' );
+					?>
+				</h2>
 				<!-- /wp:heading -->
 			</div>
 			<!-- /wp:column -->

--- a/patterns/cta-events-list.php
+++ b/patterns/cta-events-list.php
@@ -61,7 +61,12 @@
 			<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--accent-6);border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:group {"layout":{"type":"constrained"}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":3} -->
-					<h3 class="wp-block-heading"><?php echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Placeholder heading in four languages.', 'twentytwentyfive' ); ?></h3>
+					<h3 class="wp-block-heading">
+						<?php
+							/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
+							echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Placeholder heading in four languages.', 'twentytwentyfive' );
+						?>
+					</h3>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->
@@ -123,7 +128,12 @@
 			<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--accent-6);border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:group {"layout":{"type":"constrained"}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":3} -->
-					<h3 class="wp-block-heading"><?php echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Placeholder heading in four languages.', 'twentytwentyfive' ); ?></h3>
+					<h3 class="wp-block-heading">
+						<?php
+							/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
+							echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Placeholder heading in four languages.', 'twentytwentyfive' );
+						?>
+					</h3>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->

--- a/patterns/cta-events-list.php
+++ b/patterns/cta-events-list.php
@@ -63,8 +63,10 @@
 					<!-- wp:heading {"level":3} -->
 					<h3 class="wp-block-heading">
 						<?php
+						echo wp_kses_post(
 							/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
-							echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Placeholder heading in four languages.', 'twentytwentyfive' );
+							_x( '“Stories, <span lang="es">historias</span>, <span lang="uk">iсторії</span>, <span lang="el">iστορίες</span>”', 'Placeholder heading in four languages.', 'twentytwentyfive' )
+						);
 						?>
 					</h3>
 					<!-- /wp:heading -->
@@ -130,8 +132,10 @@
 					<!-- wp:heading {"level":3} -->
 					<h3 class="wp-block-heading">
 						<?php
+						echo wp_kses_post(
 							/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
-							echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Placeholder heading in four languages.', 'twentytwentyfive' );
+							_x( '“Stories, <span lang="es">historias</span>, <span lang="uk">iсторії</span>, <span lang="el">iστορίες</span>”', 'Placeholder heading in four languages.', 'twentytwentyfive' )
+						);
 						?>
 					</h3>
 					<!-- /wp:heading -->

--- a/patterns/event-rsvp.php
+++ b/patterns/event-rsvp.php
@@ -23,7 +23,12 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 			<div class="wp-block-group">
 				<!-- wp:heading {"fontSize":"xx-large"} -->
-				<h2 class="wp-block-heading has-xx-large-font-size"><?php echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Placeholder heading in four languages.', 'twentytwentyfive' ); ?></h2>
+				<h2 class="wp-block-heading has-xx-large-font-size">
+					<?php
+						/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
+						echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Placeholder heading in four languages.', 'twentytwentyfive' );
+					?>
+				</h2>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"fontSize":"x-large"} -->

--- a/patterns/event-rsvp.php
+++ b/patterns/event-rsvp.php
@@ -24,12 +24,12 @@
 			<div class="wp-block-group">
 				<!-- wp:heading {"fontSize":"xx-large"} -->
 				<h2 class="wp-block-heading has-xx-large-font-size">
-				<?php
-				echo wp_kses_post(
-					/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
-					_x( '“Stories, <span lang="es">historias</span>, <span lang="uk">iсторії</span>, <span lang="el">iστορίες</span>”', 'Placeholder heading in four languages.', 'twentytwentyfive' )
-				);
-				?>
+					<?php
+					echo wp_kses_post(
+						/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
+						_x( '“Stories, <span lang="es">historias</span>, <span lang="uk">iсторії</span>, <span lang="el">iστορίες</span>”', 'Placeholder heading in four languages.', 'twentytwentyfive' )
+					);
+					?>
 				</h2>
 				<!-- /wp:heading -->
 

--- a/patterns/event-rsvp.php
+++ b/patterns/event-rsvp.php
@@ -25,11 +25,11 @@
 				<!-- wp:heading {"fontSize":"xx-large"} -->
 				<h2 class="wp-block-heading has-xx-large-font-size">
 				<?php
-					echo wp_kses_post(
-						/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
-						_x( '“Stories, <span lang="es">historias</span>, <span lang="uk">iсторії</span>, <span lang="el">iστορίες</span>”', 'Placeholder heading in four languages.', 'twentytwentyfive' )
-					);
-					?>
+				echo wp_kses_post(
+					/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
+					_x( '“Stories, <span lang="es">historias</span>, <span lang="uk">iсторії</span>, <span lang="el">iστορίες</span>”', 'Placeholder heading in four languages.', 'twentytwentyfive' )
+				);
+				?>
 				</h2>
 				<!-- /wp:heading -->
 

--- a/patterns/event-rsvp.php
+++ b/patterns/event-rsvp.php
@@ -24,9 +24,11 @@
 			<div class="wp-block-group">
 				<!-- wp:heading {"fontSize":"xx-large"} -->
 				<h2 class="wp-block-heading has-xx-large-font-size">
-					<?php
+				<?php
+					echo wp_kses_post(
 						/* translators: This string contains the word "Stories" in four different languages with the first item in the locale's language. */
-						echo esc_html_x( '“Stories, historias, iсторії, iστορίες”', 'Placeholder heading in four languages.', 'twentytwentyfive' );
+						_x( '“Stories, <span lang="es">historias</span>, <span lang="uk">iсторії</span>, <span lang="el">iστορίες</span>”', 'Placeholder heading in four languages.', 'twentytwentyfive' )
+					);
 					?>
 				</h2>
 				<!-- /wp:heading -->


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

* adds a translator note for the strings `“Stories, historias, iсторії, iστορίες”` to clarify that the strings are intended to contain the word "Stories" in four languages.
* Modifies the context for each of the sample/placeholder headings to be consistent. In one location it differed.

**Screenshots**

N/A

**Testing Instructions**

1. Ensure the addition of the line breaks within the headings has not impacted the display negatively.