### PR TITLE
Update heading font size

### DIFF
--- a/patterns/cta-grid-products-link.php
+++ b/patterns/cta-grid-products-link.php
@@ -17,7 +17,7 @@
 	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide">
 		<!-- wp:heading {"style":{"typography":{"fontSize":"11.58rem","letterSpacing":"-0.02em"}}} -->
-		<h2 class="wp-block-heading" style="font-size:11.58rem;letter-spacing:-0.02em"><?php esc_html_e( 'Our online store.', 'twentytwentyfive' ); ?></h2>
+		<h2 class="wp-block-heading" style="font-size:9,6rem;letter-spacing:-0.02em"><?php esc_html_e( 'Our online store.', 'twentytwentyfive' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:group {"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"10rem"}} -->

--- a/patterns/cta-grid-products-link.php
+++ b/patterns/cta-grid-products-link.php
@@ -16,8 +16,8 @@
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
 	<!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide">
-		<!-- wp:heading {"style":{"typography":{"fontSize":"11.58rem","letterSpacing":"-0.02em"}}} -->
-		<h2 class="wp-block-heading" style="font-size:9,6rem;letter-spacing:-0.02em"><?php esc_html_e( 'Our online store.', 'twentytwentyfive' ); ?></h2>
+		<!-- wp:heading {"style":{"typography":{"fontSize":"9.6rem","letterSpacing":"-0.02em"}}} -->
+		<h2 class="wp-block-heading" style="font-size:9.6rem;letter-spacing:-0.02em"><?php esc_html_e( 'Our online store.', 'twentytwentyfive' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:group {"layout":{"type":"grid","columnCount":null,"minimumColumnWidth":"10rem"}} -->


### PR DESCRIPTION
**Description**

Unfortunately this is a workaround to the intended behaviour of this heading. It should ideally stretch to match the content width in all variations, but that isn't possible currently in the editor. Fixes #627. Here's how it should look with the updated font size:

**Screenshots**

![Captura de ecrã 2024-10-24, às 16 52 14](https://github.com/user-attachments/assets/d6100fd4-ccb1-498d-9290-dc05893be82b)
![Captura de ecrã 2024-10-24, às 16 35 36](https://github.com/user-attachments/assets/e652b306-1865-4b92-96d1-3980a77078c6)
![Captura de ecrã 2024-10-24, às 16 35 07](https://github.com/user-attachments/assets/bd1c57e1-c9c9-4469-a7da-9c0949ceba83)
![Captura de ecrã 2024-10-24, às 16 34 00](https://github.com/user-attachments/assets/d7e000f5-7f66-4d58-a8b1-aef6c858f4b7)
![Captura de ecrã 2024-10-24, às 16 32 18](https://github.com/user-attachments/assets/1e5ef50e-13d6-4ce7-8520-dc2845176753)

**Testing Instructions**

1. Insert the pattern
2. Confirm it looks like the above across variations