### PR TITLE
Translations: edits for capitalization and consistency

### DIFF
--- a/patterns/cta-heading-search.php
+++ b/patterns/cta-heading-search.php
@@ -18,7 +18,7 @@
 		<h2 class="wp-block-heading has-xx-large-font-size"><?php esc_html_e( 'What are you looking for?', 'twentytwentyfive' ); ?></h2>
 		<!-- /wp:heading -->
 
-		<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'Search form label.', 'twentytwentyfive' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Type here...', 'Search input field placeholder text.', 'twentytwentyfive' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'Button text. Verb', 'twentytwentyfive' ); ?>"} /-->
+		<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'Search form label.', 'twentytwentyfive' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Type here...', 'Search input field placeholder text.', 'twentytwentyfive' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'Button text. Verb.', 'twentytwentyfive' ); ?>"} /-->
 	</div>
 	<!-- /wp:group -->
 </div>

--- a/patterns/event-schedule.php
+++ b/patterns/event-schedule.php
@@ -160,7 +160,7 @@
 						<!-- wp:column {"width":"33.33%"} -->
 						<div class="wp-block-column" style="flex-basis:33.33%">
 							<!-- wp:image {"id":2774,"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"270px"}}} -->
-							<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/agenda-img-4.webp" alt="<?php esc_attr_e( 'Black and white photo of an african woman.', 'twentytwentyfive' ); ?>" class="wp-image-2774" style="aspect-ratio:1;object-fit:cover"/></figure>
+							<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/agenda-img-4.webp" alt="<?php esc_attr_e( 'Black and white photo of an African woman.', 'twentytwentyfive' ); ?>" class="wp-image-2774" style="aspect-ratio:1;object-fit:cover"/></figure>
 							<!-- /wp:image -->
 						</div>
 						<!-- /wp:column -->

--- a/patterns/event-schedule.php
+++ b/patterns/event-schedule.php
@@ -129,7 +129,7 @@
 						<!-- wp:column {"width":"33.33%"} -->
 						<div class="wp-block-column" style="flex-basis:33.33%">
 							<!-- wp:image {"id":2773,"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fixed","flexSize":"270px"}}} -->
-							<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/parthenon-square.webp" alt="<?php esc_attr_e( 'The acropolis in Athens.', 'twentytwentyfive' ); ?>" class="wp-image-2773" style="aspect-ratio:1;object-fit:cover"/></figure>
+							<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/parthenon-square.webp" alt="<?php esc_attr_e( 'The Acropolis of Athens.', 'twentytwentyfive' ); ?>" class="wp-image-2773" style="aspect-ratio:1;object-fit:cover"/></figure>
 							<!-- /wp:image -->
 						</div>
 						<!-- /wp:column -->

--- a/patterns/footer-centered.php
+++ b/patterns/footer-centered.php
@@ -29,7 +29,7 @@
 	<p class="has-text-align-center has-small-font-size">
 		<?php
 		printf(
-			/* Translators: Designed with WordPress. %s: WordPress link. */
+			/* translators: Designed with WordPress. %s: WordPress link. */
 			esc_html__( 'Designed with %s', 'twentytwentyfive' ),
 			'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfive' ) ) . '" rel="nofollow">WordPress</a>'
 		);

--- a/patterns/footer-columns.php
+++ b/patterns/footer-columns.php
@@ -69,7 +69,7 @@
 			<p class="has-small-font-size">
 			<?php
 			printf(
-				/* Translators: Designed with WordPress. %s: WordPress link. */
+				/* translators: Designed with WordPress. %s: WordPress link. */
 				esc_html__( 'Designed with %s', 'twentytwentyfive' ),
 				'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfive' ) ) . '" rel="nofollow">WordPress</a>'
 			);

--- a/patterns/footer-newsletter.php
+++ b/patterns/footer-newsletter.php
@@ -45,7 +45,7 @@
 			<p class="has-small-font-size">
 				<?php
 					printf(
-						/* Translators: Designed with WordPress. %s: WordPress link. */
+						/* translators: Designed with WordPress. %s: WordPress link. */
 						esc_html__( 'Designed with %s', 'twentytwentyfive' ),
 						'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfive' ) ) . '" rel="nofollow">WordPress</a>'
 					);

--- a/patterns/footer-social.php
+++ b/patterns/footer-social.php
@@ -31,7 +31,7 @@
 	<p class="has-text-align-center has-small-font-size">
 		<?php
 		printf(
-			/* Translators: Designed with WordPress. %s: WordPress link. */
+			/* translators: Designed with WordPress. %s: WordPress link. */
 			esc_html__( 'Designed with %s', 'twentytwentyfive' ),
 			'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfive' ) ) . '" rel="nofollow">WordPress</a>'
 		);

--- a/patterns/footer.php
+++ b/patterns/footer.php
@@ -78,7 +78,7 @@
 			<p class="has-small-font-size">
 				<?php
 				printf(
-					/* Translators: Designed with WordPress. %s: WordPress link. */
+					/* translators: Designed with WordPress. %s: WordPress link. */
 					esc_html__( 'Designed with %s', 'twentytwentyfive' ),
 					'<a href="' . esc_url( __( 'https://wordpress.org', 'twentytwentyfive' ) ) . '" rel="nofollow">WordPress</a>'
 				);

--- a/patterns/hero-podcast.php
+++ b/patterns/hero-podcast.php
@@ -46,7 +46,7 @@
 				<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"className":"is-style-text-annotation"} -->
-					<p class="is-style-text-annotation"><a href="#"><?php echo esc_html_x( 'Youtube', 'Button text', 'twentytwentyfive' ); ?></a></p>
+					<p class="is-style-text-annotation"><a href="#"><?php echo esc_html_x( 'YouTube', 'Button text', 'twentytwentyfive' ); ?></a></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:paragraph {"className":"is-style-text-annotation"} -->

--- a/patterns/hidden-search.php
+++ b/patterns/hidden-search.php
@@ -11,4 +11,4 @@
 
 ?>
 
-<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'Search form label.', 'twentytwentyfive' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Type here...', 'Search input field placeholder text', 'twentytwentyfive' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'Button text. Verb.', 'twentytwentyfive' ); ?>"} /-->
+<!-- wp:search {"label":"<?php echo esc_html_x( 'Search', 'Search form label.', 'twentytwentyfive' ); ?>","showLabel":false,"placeholder":"<?php echo esc_attr_x( 'Type here...', 'Search input field placeholder text.', 'twentytwentyfive' ); ?>","buttonText":"<?php echo esc_attr_x( 'Search', 'Button text. Verb.', 'twentytwentyfive' ); ?>"} /-->

--- a/patterns/media-instagram-grid.php
+++ b/patterns/media-instagram-grid.php
@@ -49,7 +49,7 @@
 		<!-- /wp:image -->
 
 		<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
-		<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/parthenon-square.webp" alt="<?php esc_attr_e( 'The acropolis in Athens.', 'twentytwentyfive' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
+		<figure class="wp-block-image size-full"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/images/parthenon-square.webp" alt="<?php esc_attr_e( 'The Acropolis of Athens.', 'twentytwentyfive' ); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
 		<!-- /wp:image -->
 
 		<!-- wp:image {"aspectRatio":"1","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->

--- a/patterns/services-subscriber-only-section.php
+++ b/patterns/services-subscriber-only-section.php
@@ -28,7 +28,7 @@
 				<!-- /wp:list-item -->
 
 				<!-- wp:list-item {"fontSize":"medium"} -->
-				<li class="has-medium-font-size"><?php esc_html_e( 'Join our IRL event.', 'twentytwentyfive' ); ?></li>
+				<li class="has-medium-font-size"><?php esc_html_e( 'Join our IRL events.', 'twentytwentyfive' ); ?></li>
 				<!-- /wp:list-item -->
 
 				<!-- wp:list-item {"fontSize":"medium"} -->

--- a/patterns/template-home-with-sidebar-news-blog.php
+++ b/patterns/template-home-with-sidebar-news-blog.php
@@ -85,7 +85,7 @@
 						<div class="wp-block-group has-small-font-size">
 							<!-- wp:post-terms {"term":"category","style":{"typography":{"textTransform":"uppercase","letterSpacing":"1.4px"}}} /-->
 							<!-- wp:paragraph -->
-							<p><?php echo esc_html_x( '·', 'Separator between date and categories', 'twentytwentyfive' ); ?></p>
+							<p><?php echo esc_html_x( '·', 'Separator between date and categories.', 'twentytwentyfive' ); ?></p>
 							<!-- /wp:paragraph -->
 							<!-- wp:post-date {"isLink":true} /-->
 						</div>

--- a/patterns/template-query-loop-vertical-header-blog.php
+++ b/patterns/template-query-loop-vertical-header-blog.php
@@ -44,7 +44,7 @@
 
 	<!-- wp:query-no-results -->
 		<!-- wp:paragraph -->
-		<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?></p>
+		<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search.', 'twentytwentyfive' ); ?></p>
 		<!-- /wp:paragraph -->
 	<!-- /wp:query-no-results -->
 </div>

--- a/patterns/template-query-loop.php
+++ b/patterns/template-query-loop.php
@@ -28,7 +28,7 @@
 	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
 		<!-- wp:query-no-results -->
 		<!-- wp:paragraph -->
-		<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search', 'twentytwentyfive' ); ?></p>
+		<p><?php echo esc_html_x( 'Sorry, but nothing was found. Please try a search with different keywords.', 'Message explaining that there are no results returned from a search.', 'twentytwentyfive' ); ?></p>
 		<!-- /wp:paragraph -->
 		<!-- /wp:query-no-results -->
 	</div>


### PR DESCRIPTION
1. Capitalize proper nouns: African, YouTube, and Acropolis of Athens.
2. [Use lowercase t](https://developer.wordpress.org/apis/internationalization/internationalization-guidelines/#descriptions) for `translators:` comments.
3. Add a period in the context **when it matches another string**.
4. Use plural "IRL events" in `services-subscriber-only-section.php` for consistency with the string in pricing patterns.