### PR TITLE
Fix: Parity between style variations and colors + typography presets.

### DIFF
--- a/styles/colors/06-morning.json
+++ b/styles/colors/06-morning.json
@@ -192,7 +192,8 @@
 						},
 						":hover": {
 							"color": {
-								"background": "color-mix(in srgb, var(--wp--preset--color--accent-1) 85%, transparent)"
+								"background": "color-mix(in srgb, var(--wp--preset--color--accent-1) 85%, transparent)",
+								"text": "var:preset|color|contrast"
 						}
 					}
 					},

--- a/styles/colors/08-midnight.json
+++ b/styles/colors/08-midnight.json
@@ -4,6 +4,16 @@
 	"title": "Midnight",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#4433A6",
+						"#79F3B1"
+					],
+					"name": "Midnight filter",
+					"slug": "midnight-filter"
+				}
+			],
 			"palette": [
 				{
 					"color": "#4433A6",

--- a/styles/typography/typography-preset-3.json
+++ b/styles/typography/typography-preset-3.json
@@ -32,20 +32,20 @@
 				},
 				{
 					"fluid": {
-						"max": "2rem",
-						"min": "1.75rem"
+						"max": "1.8rem",
+						"min": "1.4rem"
 					},
 					"name": "Extra Large",
-					"size": "1.75rem",
+					"size": "1.4rem",
 					"slug": "x-large"
 				},
 				{
 					"fluid": {
-						"max": "3.625rem",
-						"min": "2.625rem"
+						"max": "2.6rem",
+						"min": "2rem"
 					},
 					"name": "Extra Extra Large",
-					"size": "2.625rem",
+					"size": "2rem",
 					"slug": "xx-large"
 				}
 			]
@@ -54,14 +54,18 @@
 	"styles": {
 		"typography": {
 			"fontFamily": "var:preset|font-family|ysabeau-office",
-			"fontWeight": "400",
 			"letterSpacing": "-0.22px",
-			"lineHeight": "1.6"
+			"lineHeight": "1.5"
 		},
 		"blocks":{
 			"core/code": {
 				"typography": {
 					"letterSpacing": "0px"
+				}
+			},
+			"core/heading": {
+				"typography": {
+					"lineHeight": "1.2"
 				}
 			},
 			"core/list": {
@@ -74,30 +78,9 @@
 					"fontSize": "var:preset|font-size|medium"
 				}
 			},
-			"core/post-author": {
-				"typography": {
-					"fontSize": "var:preset|font-size|medium"
-				}
-			},
-			"core/post-author-biography": {
-				"typography": {
-					"fontSize": "var:preset|font-size|medium"
-				}
-			},
-			"core/post-author-name": {
-				"typography": {
-					"fontSize": "var:preset|font-size|medium"
-				}
-			},
 			"core/post-terms": {
 				"typography": {
 					"fontWeight": "400"
-				}
-			},
-			"core/post-title": {
-				"typography": {
-					"fontWeight": "500",
-					"letterSpacing": "-0.8px"
 				}
 			},
 			"core/pullquote": {
@@ -115,7 +98,7 @@
 			"core/site-title": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|ysabeau-office",
-					"fontSize": "var:preset|font-size|medium",
+					"fontSize": "var:preset|font-size|large",
 					"letterSpacing": "1.44px",
 					"textTransform": "uppercase"
 				}
@@ -133,6 +116,20 @@
 			"heading": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|platypi"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontSize": "var:preset|font-size|medium"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontSize": "var:preset|font-size|small",
+					"fontWeight": "400",
+					"fontStyle": "initial",
+					"letterSpacing": "initial",
+					"textTransform": "initial"
 				}
 			}
 		}

--- a/styles/typography/typography-preset-6.json
+++ b/styles/typography/typography-preset-6.json
@@ -58,11 +58,6 @@
 					}
 				}
 			},
-			"core/query-title": {
-				"typography": {
-					"fontWeight": "800"
-				}
-			},
 			"core/site-title": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|platypi",

--- a/styles/typography/typography-preset-7.json
+++ b/styles/typography/typography-preset-7.json
@@ -99,7 +99,9 @@
 			"button": {
 				"typography": {
 					"fontFamily": "var:preset|font-family|literata",
+					"fontSize": "var:preset|font-size|medium",
 					"fontWeight": "400",
+					"letterSpacing": "-0.01em",
 					"textTransform": "uppercase"
 				}
 			},


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Fixes https://github.com/WordPress/twentytwentyfive/issues/634

Fixing parity between style variations and colors + typography presets.

**Screenshots**

<!-- Add screenshots of the change, if applicable -->


https://github.com/user-attachments/assets/de95ecd6-98df-442d-986c-38d6eb7fa3d6



**Testing Instructions**

1. Open the site editor.
2. Click on all the style variations.
3. Confirm that each time one is selected, then the correspondent palette and typography should be also selected.
