### PR TITLE
add: spacing styles for heading with annotation style in dust theme

### DIFF
--- a/styles/03-dusk.json
+++ b/styles/03-dusk.json
@@ -60,6 +60,7 @@
 			"letterSpacing": "-0.18px",
 			"lineHeight": "1.5"
 		},
+		"css": ".wp-block-heading.is-style-text-annotation {padding-bottom:0.15rem;}",
 		"blocks": {
 			"core/code": {
 				"color": {


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Updated spacing as discussed in #605.

I set the bottom padding to 0.15rem instead of the originally suggested 0.2 based on a heading set in all caps still appearing to have more bottom space than the top.

**Screenshots**

<img width="721" alt="test-2" src="https://github.com/user-attachments/assets/67549209-1fda-4bbf-a050-1517e8a7857f">
<img width="694" alt="test-1" src="https://github.com/user-attachments/assets/804c3d38-b2bf-4623-bfc3-ffd535c51f94">
