### PR TITLE
Adjust outline styles on the navigation block

### DIFF
--- a/style.css
+++ b/style.css
@@ -29,6 +29,21 @@ a {
 	outline-style: solid;
 }
 
+/* Increase the bottom margin on submenus, so that the outline is visible. */
+.wp-block-navigation .wp-block-navigation-submenu .wp-block-navigation-item:not(:last-child) {
+	margin-bottom: 3px;
+}
+
+/* Increase the outline offset on the parent menu items, so that the outline does not touch the text. */
+.wp-block-navigation .wp-block-navigation-item .wp-block-navigation-item__content {
+	outline-offset: 4px;
+}
+
+/* Remove outline offset from the submenus, otherwise the outline is visible outside the submenu container. */
+.wp-block-navigation .wp-block-navigation-item ul.wp-block-navigation__submenu-container .wp-block-navigation-item__content {
+	outline-offset: 0;
+}
+
 /*
  * Progressive enhancement to reduce widows and orphans
  * https://github.com/WordPress/gutenberg/issues/55190


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
Closes https://github.com/WordPress/twentytwentyfive/issues/595

This pull request adjusts the focus outline style on the navigation block to work better with the thicker outline.

1. Increase the bottom margin on submenus, so that the outline is visible.
2. Increase the outline offset on the parent menu items, so that the outline does not touch the text.
3. Then removes that outline offset from the submenus, otherwise the outline is visible outside the submenu container.

I was not able to write 2 and 3 as one style.

**Screenshots**

In this clip I am using  Firefox on Windows 11 and I have zoomed in to 240 % only to make the style more visible for the video:

https://github.com/user-attachments/assets/d16e60cb-2114-45f3-a3b3-24f95deb163f




**Testing Instructions**
Add two navigation blocks, one with the setting "Open on click" disabled and one with it enabled.
Add submenus with at least one nested submenu. (A submenu with a submenu).

Test with different browsers. 
Use the tab key to navigate forwards through the menu.
Use tab key  and backspace to navigate backwards through the menu.

Bonus: Test other blocks that can be added to the menu and make sure that they do not break.

Note: You may see two unrelated issues:
One is a focus loss when navigating backwards.
The other is a styling problem with the nested submenu where the text has no spacing on the left side. These are issue with the block, that are unrelated to this theme.
