### PR TITLE
Twilight, section 5: Adjust the border color on the comments form block.

### DIFF
--- a/styles/05-twilight.json
+++ b/styles/05-twilight.json
@@ -206,6 +206,13 @@
 						}
 					}
 				}
+			},
+			"section-5": {
+				"blocks": {
+					"core/post-comments-form": {
+						"css": "& textarea, input:not([type=submit]){border-radius:.25rem; border-color: color-mix(in srgb, currentColor 20%, transparent) !important;} & input[type=checkbox]{margin:0 .2rem 0 0 !important;} & label {font-size: var(--wp--preset--font-size--small); }"
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Adjusts the border color on the form elements on the comments form block, so that the inputs are visible over the white background.

Closes https://github.com/WordPress/twentytwentyfive/issues/640

**Screenshots**

After:
![image](https://github.com/user-attachments/assets/506f0030-aa7d-42d4-b459-615163d2653a)


**Testing Instructions**

Go to Appearance > Editor > Styles
Enable the Twilight style variation.
Create a new post.
Add a group block and apply section style 5
Insert a comments block inside this section.
Log out and view the section with the comments blocks.