### PR TITLE
Alt: FAQs: Replace Details blocks with headings and separators.

### DIFF
--- a/patterns/text-faqs.php
+++ b/patterns/text-faqs.php
@@ -21,54 +21,77 @@
 		<h2 class="wp-block-heading has-x-large-font-size"><?php echo esc_html_x( 'Frequently Asked Questions', 'Heading of the FAQs pattern.', 'twentytwentyfive' ); ?></h2>
 		<!-- /wp:heading -->
 
-		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"default"}} -->
-		<div class="wp-block-group">
-			<!-- wp:details {"style":{"border":{"bottom":{"color":"var:preset|color|accent-6","width":"1px"}},"spacing":{"padding":{"bottom":"var:preset|spacing|30"}},"typography":{"fontStyle":"normal","fontWeight":"400"}}} -->
-			<details class="wp-block-details" style="border-bottom-color:var(--wp--preset--color--accent-6);border-bottom-width:1px;padding-bottom:var(--wp--preset--spacing--30);font-style:normal;font-weight:400">
-				<summary><?php echo esc_html_x( 'What is The Stories Book about?', 'Question in the FAQs pattern.', 'twentytwentyfive' ); ?></summary>
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"300"}}} -->
-				<p style="font-style:normal;font-weight:300"><?php echo esc_html_x( 'This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist. Fleckenstein\'s evocative imagery, Strand\'s groundbreaking modernist approach, and Kōno\'s meticulous documentation of Japanese life come together in a harmonious blend that celebrates the art of photography.', 'Answer in the FAQs pattern.', 'twentytwentyfive' ); ?></p>
-				<!-- /wp:paragraph -->
-			</details>
-			<!-- /wp:details -->
+		<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|50"}}}} -->
+		<div class="wp-block-columns">
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|accent-6","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"default"}} -->
+				<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--accent-6);border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+					<!-- wp:heading {"level":3} -->
+					<h3 class="wp-block-heading"><?php echo esc_html_x( 'What is The Stories Book about?', 'Question in the FAQs pattern.', 'twentytwentyfive' ); ?></h3>
+					<!-- /wp:heading -->
 
-			<!-- wp:details {"style":{"border":{"bottom":{"color":"var:preset|color|accent-6","width":"1px"}},"spacing":{"padding":{"bottom":"var:preset|spacing|30"}},"typography":{"fontStyle":"normal","fontWeight":"400"}}} -->
-			<details class="wp-block-details" style="border-bottom-color:var(--wp--preset--color--accent-6);border-bottom-width:1px;padding-bottom:var(--wp--preset--spacing--30);font-style:normal;font-weight:400">
-				<summary><?php echo esc_html_x( 'How much does The Stories Book cost?', 'Question in the FAQs pattern.', 'twentytwentyfive' ); ?></summary>
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"300"}}} -->
-				<p style="font-style:normal;font-weight:300"><?php echo esc_html_x( 'This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist. Fleckenstein\'s evocative imagery, Strand\'s groundbreaking modernist approach, and Kōno\'s meticulous documentation of Japanese life come together in a harmonious blend that celebrates the art of photography.', 'Answer in the FAQs pattern.', 'twentytwentyfive' ); ?></p>
-				<!-- /wp:paragraph -->
-			</details>
-			<!-- /wp:details -->
+					<!-- wp:paragraph -->
+					<p><?php echo esc_html_x( 'This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist.', 'Answer in the FAQs pattern.', 'twentytwentyfive' ); ?></p>
+					<!-- /wp:paragraph -->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:column -->
 
-			<!-- wp:details {"style":{"border":{"bottom":{"color":"var:preset|color|accent-6","width":"1px"}},"spacing":{"padding":{"bottom":"var:preset|spacing|30"}},"typography":{"fontStyle":"normal","fontWeight":"400"}}} -->
-			<details class="wp-block-details" style="border-bottom-color:var(--wp--preset--color--accent-6);border-bottom-width:1px;padding-bottom:var(--wp--preset--spacing--30);font-style:normal;font-weight:400">
-				<summary><?php echo esc_html_x( 'When will The Stories Book be released?', 'Question in the FAQs pattern.', 'twentytwentyfive' ); ?></summary>
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"300"}}} -->
-				<p style="font-style:normal;font-weight:300"><?php echo esc_html_x( 'This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist. Fleckenstein\'s evocative imagery, Strand\'s groundbreaking modernist approach, and Kōno\'s meticulous documentation of Japanese life come together in a harmonious blend that celebrates the art of photography.', 'Answer in the FAQs pattern.', 'twentytwentyfive' ); ?></p>
-				<!-- /wp:paragraph -->
-			</details>
-			<!-- /wp:details -->
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|accent-6","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"default"}} -->
+				<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--accent-6);border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+					<!-- wp:heading {"level":3} -->
+					<h3 class="wp-block-heading"><?php echo esc_html_x( 'How much does The Stories Book cost?', 'Question in the FAQs pattern.', 'twentytwentyfive' ); ?></h3>
+					<!-- /wp:heading -->
 
-			<!-- wp:details {"style":{"border":{"bottom":{"color":"var:preset|color|accent-6","width":"1px"}},"spacing":{"padding":{"bottom":"var:preset|spacing|30"}},"typography":{"fontStyle":"normal","fontWeight":"400"}}} -->
-			<details class="wp-block-details" style="border-bottom-color:var(--wp--preset--color--accent-6);border-bottom-width:1px;padding-bottom:var(--wp--preset--spacing--30);font-style:normal;font-weight:400">
-				<summary><?php echo esc_html_x( 'Are signed copies available?', 'Question in the FAQs pattern.', 'twentytwentyfive' ); ?></summary>
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"300"}}} -->
-				<p style="font-style:normal;font-weight:300"><?php echo esc_html_x( 'This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist. Fleckenstein\'s evocative imagery, Strand\'s groundbreaking modernist approach, and Kōno\'s meticulous documentation of Japanese life come together in a harmonious blend that celebrates the art of photography.', 'Answer in the FAQs pattern.', 'twentytwentyfive' ); ?></p>
-				<!-- /wp:paragraph -->
-			</details>
-			<!-- /wp:details -->
-
-			<!-- wp:details {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}}} -->
-			<details class="wp-block-details" style="font-style:normal;font-weight:400">
-				<summary><?php echo esc_html_x( 'Will The Stories Book be available in other languages other that English?', 'Question in the FAQs pattern', 'twentytwentyfive' ); ?></summary>
-				<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"300"}}} -->
-				<p style="font-style:normal;font-weight:300"><?php echo esc_html_x( 'This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist. Fleckenstein\'s evocative imagery, Strand\'s groundbreaking modernist approach, and Kōno\'s meticulous documentation of Japanese life come together in a harmonious blend that celebrates the art of photography.', 'Answer in the FAQs pattern.', 'twentytwentyfive' ); ?></p>
-				<!-- /wp:paragraph -->
-			</details>
-			<!-- /wp:details -->
+					<!-- wp:paragraph -->
+					<p><?php echo esc_html_x( 'This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist.', 'Answer in the FAQs pattern.', 'twentytwentyfive' ); ?></p>
+					<!-- /wp:paragraph -->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:column -->
 		</div>
-		<!-- /wp:group -->
+		<!-- /wp:columns -->
+
+		<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|50"}}}} -->
+		<div class="wp-block-columns">
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|accent-6","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"default"}} -->
+				<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--accent-6);border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+					<!-- wp:heading {"level":3} -->
+					<h3 class="wp-block-heading"><?php echo esc_html_x( 'When will The Stories Book be released?', 'Question in the FAQs pattern.', 'twentytwentyfive' ); ?></h3>
+					<!-- /wp:heading -->
+
+					<!-- wp:paragraph -->
+					<p><?php echo esc_html_x( 'This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist.', 'Answer in the FAQs pattern.', 'twentytwentyfive' ); ?></p>
+					<!-- /wp:paragraph -->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:column -->
+
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|accent-6","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"default"}} -->
+				<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--accent-6);border-top-width:1px;padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+					<!-- wp:heading {"level":3} -->
+					<h3 class="wp-block-heading"><?php echo esc_html_x( 'Are signed copies available?', 'Question in the FAQs pattern.', 'twentytwentyfive' ); ?></h3>
+					<!-- /wp:heading -->
+
+					<!-- wp:paragraph -->
+					<p><?php echo esc_html_x( 'This exquisite compilation showcases a diverse array of photographs that capture the essence of different eras and cultures, reflecting the unique styles and perspectives of each artist.', 'Answer in the FAQs pattern.', 'twentytwentyfive' ); ?></p>
+					<!-- /wp:paragraph -->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:column -->
+		</div>
+		<!-- /wp:columns -->
 	</div>
 	<!-- /wp:group -->
 </div>

--- a/patterns/text-faqs.php
+++ b/patterns/text-faqs.php
@@ -5,7 +5,7 @@
  * Categories: text, about
  * Keywords: faq, about, frequently asked questions
  * Viewport width: 1400
- * Description: A FAQs section with a FAQ heading and list of toggle questions and answers.
+ * Description: A FAQs section with a FAQ heading and list of questions and answers.
  *
  * @package    WordPress
  * @subpackage Twenty_Twenty_Five


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

Fixes https://github.com/WordPress/twentytwentyfive/issues/638

Alternative to https://github.com/WordPress/twentytwentyfive/pull/639 - based on @beafialho's comment [here](https://github.com/WordPress/twentytwentyfive/pull/639#issuecomment-2441222289).

I can't edit fork branches, so I created this PR. Props to @sabernhardt, @beafialho, @carolinan 

**Screenshots**

<!-- Add screenshots of the change, if applicable -->

https://github.com/user-attachments/assets/79474982-c9de-442f-a617-42498bdc2fd6


**Testing Instructions**

1. Create a page.
2. Add the FAQ pattern.
3. Confirm that it looks like what Bea proposed [here](https://github.com/WordPress/twentytwentyfive/pull/639#issuecomment-2441222289).
