### PR TITLE
fix: layout breaks when there are many categories in default single p…

### DIFF
--- a/patterns/hidden-written-by.php
+++ b/patterns/hidden-written-by.php
@@ -10,7 +10,7 @@
  */
 
 ?>
-<!-- wp:group {"style":{"spacing":{"blockGap":"0.2em","margin":{"bottom":"var:preset|spacing|60"}}},"textColor":"accent-4","fontSize":"small","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"0.2em","margin":{"bottom":"var:preset|spacing|60"}}},"textColor":"accent-4","fontSize":"small","layout":{"type":"flex","flexWrap":"wrap"}} -->
 <div class="wp-block-group has-accent-4-color has-text-color has-link-color has-small-font-size" style="margin-bottom:var(--wp--preset--spacing--60)">
 	<!-- wp:paragraph -->
 	<p><?php esc_html_e( 'Written by ', 'twentytwentyfive' ); ?></p>


### PR DESCRIPTION
**Description**
Closes #644

This PR fixes the issue where the layout breaks when there are many categories in the default single post template. Changing the `flexWrap` property of the parent group from `nowrap` to `wrap` resolves this.

**Screenshots**
![image](https://github.com/user-attachments/assets/168b4fc0-63b1-4f49-b3af-fdd22a503a2b)


**Testing Instructions**

Install https://github.com/WordPress/theme-test-data
view the "Edge Case: Many Categories" post.

Alternatively, create a post with more categories (about 10+) and view the post.