### PR TITLE
Twilight, Section 5: Adjust the border color for search input

### DIFF
--- a/styles/05-twilight.json
+++ b/styles/05-twilight.json
@@ -245,7 +245,7 @@
 						"css": "& textarea, input:not([type=submit]){border-radius:.25rem; border-color: color-mix(in srgb, currentColor 20%, transparent) !important;} & input[type=checkbox]{margin:0 .2rem 0 0 !important;} & label {font-size: var(--wp--preset--font-size--small); }"
 					},
 					"core/search": {
-						"css": "& .wp-block-search__input{border-color: color-mix(in srgb, currentColor 20%, transparent) !important;}"
+						"css": "& .wp-block-search__input{border-color: color-mix(in srgb, currentColor 20%, transparent);}"
 					}
 				}
 			}

--- a/styles/05-twilight.json
+++ b/styles/05-twilight.json
@@ -243,6 +243,9 @@
 				"blocks": {
 					"core/post-comments-form": {
 						"css": "& textarea, input:not([type=submit]){border-radius:.25rem; border-color: color-mix(in srgb, currentColor 20%, transparent) !important;} & input[type=checkbox]{margin:0 .2rem 0 0 !important;} & label {font-size: var(--wp--preset--font-size--small); }"
+					},
+					"core/search": {
+						"css": "& .wp-block-search__input{border-color: color-mix(in srgb, currentColor 20%, transparent) !important;}"
 					}
 				}
 			}


### PR DESCRIPTION
**Description**
Closes #649

Adjust the border color on form elements in the search form block to make the inputs stand out against the white background. Previously, they were hard to see because the accent color was too similar to the background color.

**Screenshots**
![image](https://github.com/user-attachments/assets/93faa403-f280-4bda-8001-987c14b2703f)

**Testing Instructions**
1. Open the **Appearance** menu, then go to **Editor** > **Styles**.
2. Turn on the **Twilight** style variation.
3. Create a new page.
4. Add a **Group Block** to the page, then select **Section Style 5** for it.
5. Inside this section, insert a **Search Block**.
6. Visit the page to see the section with the search block displayed.
