### PR TITLE
Ensure Quote Block Borders are Visible Across All Color Variations and Sections

### DIFF
--- a/styles/07-sunrise.json
+++ b/styles/07-sunrise.json
@@ -304,9 +304,6 @@
 					"fontWeight": "600",
 					"letterSpacing": "-0.24px"
 				},
-				"border": {
-					"color": "var:preset|color|accent-2"
-				},
 				"elements": {
 					"cite": {
 						"typography": {

--- a/styles/colors/07-sunrise.json
+++ b/styles/colors/07-sunrise.json
@@ -108,9 +108,6 @@
 				"color": {
 					"text": "var:preset|color|accent-2"
 				},
-				"border": {
-					"color": "var:preset|color|accent-2"
-				},
 				"elements": {
 					"cite": {
 						"color": {

--- a/theme.json
+++ b/theme.json
@@ -427,8 +427,7 @@
 			"core/quote": {
 				"border": {
 					"style": "solid",
-					"width": "0 0 0 2px",
-					"color": "var:preset|color|contrast"
+					"width": "0 0 0 2px"
 				},
 				"spacing": {
 					"blockGap": "var:preset|spacing|30",


### PR DESCRIPTION
**Description**
Closes #653 

This PR resolves the issue, and now the borders of quote blocks are displayed in all themes by removing the border color from `theme.json`.

**Screenshots**
![image](https://github.com/user-attachments/assets/5bdf4c9f-e55c-44d1-9721-063cbc3542db)

**Testing Instructions**
1. Start by creating a new page or post.
2. Add a "Group" block and apply "Section Style 5" to it.
3. Within this group, insert a "Quote" block.
4. Preview the page or post.
