### PR TITLE
Remove text color from the term description block

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -568,9 +568,6 @@
 				}
 			},
 			"core/term-description": {
-				"color":{
-					"text": "var:preset|color|accent-4"
-				},
 				"typography": {
 					"fontSize": "var:preset|font-size|medium"
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**
By removing the text color from the term description block, the number of color contrast issues when the block is used in a "section" is reduced.

Closes https://github.com/WordPress/twentytwentyfive/issues/655

**Screenshots**
Because of the large number of contrast issues, I will not provide screenshots or videos of all before and after scenarios.
***After***


https://github.com/user-attachments/assets/be6081ac-310d-4ff1-a637-089aa40980f3




**Testing Instructions**
The term description block is easiest to test on archive templates, since this type of template is the only template that shows the block on the front.

Go to Appearance > Editor > Templates
Select to edit the archive template.
This template already has a term description block placed, but to test the colors, you need to place it inside a group (or column) with a section style applied.

Then change the section style and the theme style variation to test the possible combinations.