### PR TITLE
Fix: Rename "Post format" category to "Post formats"

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -110,7 +110,7 @@ if ( ! function_exists( 'twentytwentyfive_pattern_categories' ) ) :
 		register_block_pattern_category(
 			'twentytwentyfive_post-format',
 			array(
-				'label'       => __( 'Post format', 'twentytwentyfive' ),
+				'label'       => __( 'Post formats', 'twentytwentyfive' ),
 				'description' => __( 'A collection of post format patterns.', 'twentytwentyfive' ),
 			)
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Twenty Twenty-Five! Please follow the Contributing Guidelines:
https://github.com/WordPress/twentytwentyfive/blob/trunk/README.md#contributing -->

**Description**

<!-- Describe the purpose or reason for the pull request -->
Fixes https://github.com/WordPress/twentytwentyfive/issues/658

Renaming the category to "Post formats" (plural), both to fix the typo (there's more than one pattern in the category), and to make it consistent with the other categories.

This involves changing a translatable string, so we should probably involve #polyglots 

**Screenshots**

<!-- Add screenshots of the change, if applicable -->
<img width="533" alt="Screenshot 2024-10-29 at 17 43 33" src="https://github.com/user-attachments/assets/5824b256-ad12-46ea-9c65-5b6449b67589">

**Testing Instructions**

1. Create a page.
2. Open the inserter.
3. Confirm that the category is "Post formats"
